### PR TITLE
Add best effort support for locating WinSDK tools

### DIFF
--- a/edk2toollib/windows/capsule/cat_generator.py
+++ b/edk2toollib/windows/capsule/cat_generator.py
@@ -65,7 +65,7 @@ class CatGenerator(object):
         if(PathToInf2CatTool is None):
             PathToInf2CatTool = FindToolInWinSdk("Inf2Cat.exe")
         # check if exists
-        if not os.path.exists(PathToInf2CatTool):
+        if PathToInf2CatTool is None or not os.path.exists(PathToInf2CatTool):
             raise Exception("Can't find Inf2Cat on this machine.  Please install the Windows 10 WDK - "
                             "https://developer.microsoft.com/en-us/windows/hardware/windows-driver-kit")
 

--- a/edk2toollib/windows/locate_tools.py
+++ b/edk2toollib/windows/locate_tools.py
@@ -1,9 +1,11 @@
 # @file locate_tools.py
 # This module provides python services that locate common development tools using vswhere.exe,
-# vsvars.bat, and other Windows based tools.  This will only work on systems running Windows
-# and with dev tools installed.
+# vsvars.bat, and other Windows based tools.  This works best on systems running Windows
+# and with dev tools installed but will attempt to use known paths for WinSDK if the dev
+# tools are not available.  This is only a best effort to locate the SDK tools in well
+# known/default install locations.
 #
-# Dev Tools:
+# Suggested Dev Tools:
 #   Current Windows SDKs
 #   Visual Studio 2017 Build Tools or newer
 #
@@ -107,7 +109,7 @@ def GetVsWherePath(fail_on_not_found=True):
 ####
 # Finds a product with VS Where
 ####
-def FindWithVsWhere(products="*"):
+def FindWithVsWhere(products: str = "*"):
     cmd = "-latest -nologo -all -property installationPath"
     vs_where_path = GetVsWherePath()
     if vs_where_path is None:
@@ -135,11 +137,16 @@ def FindWithVsWhere(products="*"):
 # keys: enumerable list with names of env variables to collect after bat run
 # arch: arch to run.  amd64, x86, ??
 # returns a dictionary of the interesting environment variables
-def QueryVcVariables(keys, arch="amd64"):
+def QueryVcVariables(keys: dict, arch: str = None, product: str = None):
     """Launch vcvarsall.bat and read the settings from its environment"""
+    if product is None:
+        product = "*"
+    if arch is None:
+        # TODO: look up host architecture?
+        arch = "amd64"
     interesting = set(keys)
     result = {}
-    ret, vs_path = FindWithVsWhere()
+    ret, vs_path = FindWithVsWhere(product)
     if ret != 0:
         logging.warning("We didn't find VS path or otherwise failed to invoke vsWhere")
         raise ValueError("Bad VC")
@@ -237,20 +244,17 @@ def _CheckArchOfMatch(match):
 
 # does a glob in the folder that your sdk is
 # uses the environmental variable WindowsSdkDir and tries to use WindowsSDKVersion
-def FindToolInWinSdk(tool, product="*"):
-    ret, vs_path = FindWithVsWhere(product)
-    if ret != 0:
-        logging.warning("We didn't find VS path for the given product")
-        raise ValueError(product)
+def FindToolInWinSdk(tool, product=None, arch=None):
     variables = ["WindowsSdkDir", "WindowsSDKVersion"]
     # get the value with QueryVcVariables
-    results = QueryVcVariables(variables, product=product)
-    # Get the variables we care about
-    sdk_dir = results["WindowsSdkDir"]
-    sdk_ver = results["WindowsSDKVersion"]
-    if not os.path.isdir(sdk_dir):
-        raise FileNotFoundError("Unable to find SDK directory")
-        return None
+    try:
+        results = QueryVcVariables(variables, product, arch)
+        # Get the variables we care about
+        sdk_dir = results["WindowsSdkDir"]
+        sdk_ver = results["WindowsSDKVersion"]
+    except ValueError:
+        sdk_dir = os.path.join(os.getenv("ProgramFiles(x86)"), "Windows Kits", "10", "bin")
+        sdk_ver = "0.0.0.0"
     sdk_dir = os.path.realpath(sdk_dir)
     search_pattern = os.path.join(sdk_dir, "**", tool)
 

--- a/edk2toollib/windows/locate_tools.py
+++ b/edk2toollib/windows/locate_tools.py
@@ -284,5 +284,4 @@ def FindToolInWinSdk(tool, product=None, arch=None):
             top_match = match
     if top_match is None:
         logging.critical("We weren't able to find {}".format(tool))
-        raise FileNotFoundError(tool)
     return top_match

--- a/edk2toollib/windows/locate_tools.py
+++ b/edk2toollib/windows/locate_tools.py
@@ -147,7 +147,7 @@ def QueryVcVariables(keys: dict, arch: str = None, product: str = None):
     interesting = set(keys)
     result = {}
     ret, vs_path = FindWithVsWhere(product)
-    if ret != 0:
+    if ret != 0 or vs_path is None:
         logging.warning("We didn't find VS path or otherwise failed to invoke vsWhere")
         raise ValueError("Bad VC")
     vcvarsall_path = os.path.join(vs_path, "VC", "Auxiliary", "Build", "vcvarsall.bat")

--- a/edk2toollib/windows/locate_tools_test.py
+++ b/edk2toollib/windows/locate_tools_test.py
@@ -1,0 +1,51 @@
+# @file locate_tools_test.py
+# unit test for locate_tools module.  Only runs on Windows machines.
+#
+#
+# Copyright (c) Microsoft Corporation
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+import unittest
+import sys
+import os
+import edk2toollib.windows.locate_tools as locate_tools
+
+
+class LocateToolsTest(unittest.TestCase):
+
+    @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
+    def test_GetVsWherePath(self):
+        # Gets VSWhere
+        old_vs_path = locate_tools.GetVsWherePath()
+        os.remove(old_vs_path)
+        self.assertFalse(os.path.isfile(old_vs_path), "This should be deleted")
+        vs_path = locate_tools.GetVsWherePath()
+        self.assertTrue(os.path.isfile(vs_path), "This should be back")
+
+    @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
+    def test_FindWithVsWhere(self):
+        # Finds something with VSWhere
+        ret, star_prod = locate_tools.FindWithVsWhere()
+        self.assertEqual(ret, 0, "Return code should be zero")
+        self.assertNotEqual(star_prod, None, "We should have found this product")
+        ret, bad_prod = locate_tools.FindWithVsWhere("bad_prod")
+        self.assertEqual(ret, 0, "Return code should be zero")
+        self.assertEqual(bad_prod, None, "We should not have found this product")
+
+    @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
+    def test_QueryVcVariables(self):
+        keys = ["VCINSTALLDIR", "WindowsSDKVersion"]
+        results = locate_tools.QueryVcVariables(keys)
+
+        self.assertIsNotNone(results["VCINSTALLDIR"])
+        self.assertIsNotNone(results["WindowsSDKVersion"])
+
+    @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
+    def test_FindToolInWinSdk(self):
+        results = locate_tools.FindToolInWinSdk("signtool.exe")
+        self.assertIsNotNone(results)
+        self.assertTrue(os.path.isfile(results))
+        results = locate_tools.FindToolInWinSdk("this_tool_should_never_exist.exe")
+        self.assertIsNone(results)

--- a/edk2toollib/windows/locate_tools_test.py
+++ b/edk2toollib/windows/locate_tools_test.py
@@ -33,7 +33,7 @@ class LocateToolsTest(unittest.TestCase):
         ret, bad_prod = locate_tools.FindWithVsWhere("bad_prod")
         self.assertEqual(ret, 0, "Return code should be zero")
         self.assertEqual(bad_prod, None, "We should not have found this product")
-    
+
     @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
     def test_QueryVcVariables(self):
         keys = ["VCINSTALLDIR", "WindowsSDKVersion"]
@@ -44,19 +44,19 @@ class LocateToolsTest(unittest.TestCase):
 
         self.assertIsNotNone(results["VCINSTALLDIR"])
         self.assertIsNotNone(results["WindowsSDKVersion"])
-    
+
     @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
     def test_FindInf2CatToolInWinSdk(self):
         results = locate_tools.FindToolInWinSdk("inf2cat.exe")
         self.assertIsNotNone(results)
         self.assertTrue(os.path.isfile(results))
-    
+
     @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
-    def test_FindToolInWinSdk(self):        
+    def test_FindToolInWinSdk(self):
         results = locate_tools.FindToolInWinSdk("signtool.exe")
         self.assertIsNotNone(results)
         self.assertTrue(os.path.isfile(results))
-        
+
         results = locate_tools.FindToolInWinSdk("this_tool_should_never_exist.exe")
         self.assertIsNone(results)
 

--- a/edk2toollib/windows/locate_tools_test.py
+++ b/edk2toollib/windows/locate_tools_test.py
@@ -54,17 +54,15 @@ class LocateToolsTest(unittest.TestCase):
     def test_QueryVcVariablesWithNoValidProduct(self):
         keys = ["VCINSTALLDIR", "WindowsSDKVersion"]
         with self.assertRaises(ValueError):
-            results = locate_tools.QueryVcVariables(keys, product="YouWontFindThis")
+            locate_tools.QueryVcVariables(keys, product="YouWontFindThis")
 
     @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
     def test_QueryVcVariablesWithVariableNotFound(self):
         keys = ["YouWontFindMe", "WindowsSDKVersion"]
         with self.assertRaises(ValueError):
-            results = locate_tools.QueryVcVariables(keys)
+            locate_tools.QueryVcVariables(keys)
 
     @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
     def test_FindToolInWinSdkWithNoValidProduct(self):
         results = locate_tools.FindToolInWinSdk("WontFind.exe", product="YouWontFindThis")
         self.assertIsNone(results)
-
-

--- a/edk2toollib/windows/locate_tools_test.py
+++ b/edk2toollib/windows/locate_tools_test.py
@@ -49,3 +49,22 @@ class LocateToolsTest(unittest.TestCase):
         self.assertTrue(os.path.isfile(results))
         results = locate_tools.FindToolInWinSdk("this_tool_should_never_exist.exe")
         self.assertIsNone(results)
+
+    @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
+    def test_QueryVcVariablesWithNoValidProduct(self):
+        keys = ["VCINSTALLDIR", "WindowsSDKVersion"]
+        with self.assertRaises(ValueError):
+            results = locate_tools.QueryVcVariables(keys, product="YouWontFindThis")
+
+    @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
+    def test_QueryVcVariablesWithVariableNotFound(self):
+        keys = ["YouWontFindMe", "WindowsSDKVersion"]
+        with self.assertRaises(ValueError):
+            results = locate_tools.QueryVcVariables(keys)
+
+    @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
+    def test_FindToolInWinSdkWithNoValidProduct(self):
+        results = locate_tools.FindToolInWinSdk("WontFind.exe", product="YouWontFindThis")
+        self.assertIsNone(results)
+
+

--- a/edk2toollib/windows/locate_tools_test.py
+++ b/edk2toollib/windows/locate_tools_test.py
@@ -56,9 +56,9 @@ class LocateToolsTest(unittest.TestCase):
         results = locate_tools.FindToolInWinSdk("signtool.exe")
         self.assertIsNotNone(results)
         self.assertTrue(os.path.isfile(results))
-        with self.assertRaises(FileNotFoundError):
-            results = locate_tools.FindToolInWinSdk("this_tool_should_never_exist.exe")
-            self.assertIsNone(results)
+        
+        results = locate_tools.FindToolInWinSdk("this_tool_should_never_exist.exe")
+        self.assertIsNone(results)
 
     @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
     def test_QueryVcVariablesWithNoValidProduct(self):
@@ -74,6 +74,5 @@ class LocateToolsTest(unittest.TestCase):
 
     @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
     def test_FindToolInWinSdkWithNoValidProduct(self):
-        with self.assertRaises(FileNotFoundError):
-            results = locate_tools.FindToolInWinSdk("WontFind.exe", product="YouWontFindThis")
-            self.assertIsNone(results)
+        results = locate_tools.FindToolInWinSdk("WontFind.exe", product="YouWontFindThis")
+        self.assertIsNone(results)

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,8 @@ Examples:
 
 All content in this repository is licensed under [BSD-2-Clause Plus Patent License](license.txt).
 
+[![PyPI - License](https://img.shields.io/pypi/l/edk2_pytool_library.svg)](https://pypi.org/project/edk2-pytool-library/)
+
 ## Usage
 
 NOTE: It is strongly recommended that you use python virtual environments.  Virtual environments avoid changing the global python workspace and causing conflicting dependencies.  Virtual environments are lightweight and easy to use.  [Learn more](https://docs.python.org/3/library/venv.html)
@@ -40,12 +42,13 @@ https://github.com/microsoft/mu_pip_python_library
 
 ## Current Status
 
-Todo: pypi badge here
+[![PyPI](https://img.shields.io/pypi/v/edk2_pytool_library.svg)](https://pypi.org/project/edk2-pytool-library/)
 
-| Host Type | Toolchain | Build | Status |
-| :-------- | :-------- | :---- | :----- |
-| Linux Ubuntu 1604 | Python 3.7.x | PR Gate | [![Build Status](https://dev.azure.com/tianocore/edk2-pytools-library/_apis/build/status/edk2-pytool-library%20-%20PR%20Gate%20-%20Linux?branchName=feature/proposedinitialcode)](https://dev.azure.com/tianocore/edk2-pytools-library/_build/latest?definitionId=1&branchName=feature/proposedinitialcode) |
-|Windows Server 2019 | Python 3.7.x | PR Gate | [![Build Status](https://dev.azure.com/tianocore/edk2-pytools-library/_apis/build/status/Edk2-PyTool-Library%20PR%20build%20-%20Win%20-%20VS2019?branchName=feature/proposedinitialcode)](https://dev.azure.com/tianocore/edk2-pytools-library/_build/latest?definitionId=2&branchName=feature/proposedinitialcode) |
+| Host Type | Toolchain | Branch | Build Status | Test Status | Code Coverage |
+| :-------- | :-------- | :---- | :----- | :---- | :--- |
+| Linux Ubuntu 1604 | Python 3.7.x | master | [![Build Status](https://dev.azure.com/tianocore/edk2-pytools-library/_apis/build/status/edk2-pytool-library%20-%20PR%20Gate%20-%20Linux)](https://dev.azure.com/tianocore/edk2-pytools-library/_build/latest?definitionId=1) | ![Azure DevOps tests](https://img.shields.io/azure-devops/tests/tianocore/edk2-pytools-library/1.svg) | ![Azure DevOps coverage](https://img.shields.io/azure-devops/coverage/tianocore/edk2-pytools-library/1.svg) |
+| Windows Server 2019 | Python 3.7.x | master | [![Build Status](https://dev.azure.com/tianocore/edk2-pytools-library/_apis/build/status/Edk2-PyTool-Library%20PR%20build%20-%20Win%20-%20VS2019)](https://dev.azure.com/tianocore/edk2-pytools-library/_build/latest?definitionId=2) | ![Azure DevOps tests](https://img.shields.io/azure-devops/tests/tianocore/edk2-pytools-library/2.svg)| ![Azure DevOps coverage](https://img.shields.io/azure-devops/coverage/tianocore/edk2-pytools-library/2.svg) |
+
 
 
 ## Contribution Process

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,12 @@ NOTE: It is strongly recommended that you use python virtual environments.  Virt
 
 ## Release Version History
 
+### Version 0.9.1-dev
+
+* Features:
+  * Add support for getting WinSdk tools on platforms without VS2017 or newer
+* Bugs:
+
 ### Version 0.9.00
 
 Initial release of library with functionality ported from Project Mu.


### PR DESCRIPTION
For platforms that don't have VS2017 or newer installed the vswhere based solution for locating the WinSDK dir doesn't work.  This change adds support for a best effort to look in known default install directories for the WinSDK tools.   The prefered method is still to use VsWhere and the vsvars files but this can help on older platforms.