### PR TITLE
Remove quoting of command in Inf2Cat before calling RunCmd

### DIFF
--- a/edk2toollib/utility_functions.py
+++ b/edk2toollib/utility_functions.py
@@ -147,6 +147,9 @@ def timing(f):
 # @param outstream - capture output to a stream.
 # @param environ - shell environment variables dictionary that replaces the one inherited from the
 #                  current process.
+# @param logging_level - log level to log output at.  Default is INFO
+# @param raise_exception_on_nonzero - Setting to true causes exception to be raised if the cmd
+#                                     return code is not zero.
 #
 # @return returncode of called cmd
 ####

--- a/edk2toollib/windows/capsule/cat_generator.py
+++ b/edk2toollib/windows/capsule/cat_generator.py
@@ -69,10 +69,6 @@ class CatGenerator(object):
             raise Exception("Can't find Inf2Cat on this machine.  Please install the Windows 10 WDK - "
                             "https://developer.microsoft.com/en-us/windows/hardware/windows-driver-kit")
 
-        # Adjust for spaces in the path (when calling the command).
-        if " " in PathToInf2CatTool:
-            PathToInf2CatTool = '"' + PathToInf2CatTool + '"'
-
         OutputFolder = os.path.dirname(OutputCatFile)
         # Make Cat file
         cmd = "/driver:. /os:" + self.OperatingSystem + "_" + self.Arch + " /verbose"


### PR DESCRIPTION
This is unnecessary code as RunCmd strips it off and will add it if necessary.
Also update RunCmd function header to provide details for two additional parameters.