### PR TITLE
Change QueryVcVariables keys to be case insensitive due to how window…

### DIFF
--- a/edk2toollib/windows/locate_tools.py
+++ b/edk2toollib/windows/locate_tools.py
@@ -156,13 +156,14 @@ def FindWithVsWhere(products: str = "*", vs_version: str = None):
 # vs_version: helper to find version of supported VS version (example vs2019).
 # returns a dictionary of the interesting environment variables
 def QueryVcVariables(keys: dict, arch: str = None, product: str = None, vs_version: str = None):
-    """Launch vcvarsall.bat and read the settings from its environment"""
+    """Launch vcvarsall.bat and read the settings from its environment.  This is a windows only function
+    and Windows is case insensitive for the keys"""
     if product is None:
         product = "*"
     if arch is None:
         # TODO: look up host architecture?
         arch = "amd64"
-    interesting = set(keys)
+    interesting = set(x.upper() for x in keys)
     result = {}
     ret, vs_path = FindWithVsWhere(product, vs_version)
     if ret != 0 or vs_path is None:
@@ -181,7 +182,7 @@ def QueryVcVariables(keys: dict, arch: str = None, product: str = None, vs_versi
                 continue
             line = line.strip()
             key, value = line.split('=', 1)
-            if key in interesting:
+            if key.upper() in interesting:
                 if value.endswith(os.pathsep):
                     value = value[:-1]
                 result[key] = value

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,11 @@ NOTE: It is strongly recommended that you use python virtual environments.  Virt
 
 ## Release Version History
 
+### Version 0.9.2
+
+* Bugs:
+  * Change QueryVcVariables so environment variable keys are not case sensitive.  On Windows these are not case sensitive and "Path" is not consistent.
+
 ### Version 0.9.1
 
 * Features:


### PR DESCRIPTION
Windows environment variables are can insensitive yet QueryVcVariables was matching case.  Since this function is a windows only function update it to compare keys without regard for letter case. 