### PR TITLE
[Bug Fix] Fix typo in RunPythonScript parameters

### DIFF
--- a/edk2toollib/utility_functions.py
+++ b/edk2toollib/utility_functions.py
@@ -228,7 +228,7 @@ def RunPythonScript(pythonfile, params, capture=True, workingdir=None, outfile=N
     params = pythonfile + " " + params
     return RunCmd(sys.executable, params, capture=capture, workingdir=workingdir, outfile=outfile,
                   outstream=outstream, environ=environ, logging_level=logging_level,
-                  xraise_exception_on_nonzero=raise_exception_on_nonzero)
+                  raise_exception_on_nonzero=raise_exception_on_nonzero)
 ####
 # Locally Sign input file using Windows SDK signtool.  This will use a local Pfx file.
 # WARNING!!! : This should not be used for production signing as that process should follow stronger

--- a/edk2toollib/utility_functions_test.py
+++ b/edk2toollib/utility_functions_test.py
@@ -1,0 +1,24 @@
+# @file utility_functions_test.py
+# unit test for locate_tools module.  Only runs on Windows machines.
+#
+#
+# Copyright (c) Microsoft Corporation
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+import unittest
+import sys
+import os
+import edk2toollib.utility_functions as utilities
+
+
+class UtilityFunctionsTest(unittest.TestCase):
+
+    def test_RunPythonScript(self): # simple run yourself!
+        path = __file__
+        working_dir = os.path.dirname(__file__)
+        utilities.RunPythonScript(path, "", working_dir)
+
+# DO NOT PUT A MAIN FUNCTION HERE
+#  this test runs itself to test runpython script, which is a tad bit strange yes.

--- a/edk2toollib/utility_functions_test.py
+++ b/edk2toollib/utility_functions_test.py
@@ -21,4 +21,4 @@ class UtilityFunctionsTest(unittest.TestCase):
         utilities.RunPythonScript(path, "", working_dir)
 
 # DO NOT PUT A MAIN FUNCTION HERE
-#  this test runs itself to test runpython script, which is a tad bit strange yes.
+# this test runs itself to test runpython script, which is a tad bit strange yes.

--- a/edk2toollib/utility_functions_test.py
+++ b/edk2toollib/utility_functions_test.py
@@ -1,5 +1,5 @@
 # @file utility_functions_test.py
-# unit test for locate_tools module.  Only runs on Windows machines.
+# unit test for utility_functions module.
 #
 #
 # Copyright (c) Microsoft Corporation
@@ -15,10 +15,25 @@ import edk2toollib.utility_functions as utilities
 
 class UtilityFunctionsTest(unittest.TestCase):
 
-    def test_RunPythonScript(self): # simple run yourself!
+    def test_RunPythonScript(self):  # simple run yourself!
         path = __file__
         working_dir = os.path.dirname(__file__)
-        utilities.RunPythonScript(path, "", working_dir)
+        ret = utilities.RunPythonScript(path, "", working_dir)
+        self.assertEqual(ret, 0)
+        # test it with all the named parameters
+        ret = utilities.RunPythonScript(path, "", capture=False, workingdir=working_dir,
+                                        raise_exception_on_nonzero=True)
+        self.assertEqual(ret, 0)
+        # now try a bad path
+        bad_path = __file__ + ".super.bad"
+        ret = utilities.RunPythonScript(bad_path, "", capture=False, workingdir=None, raise_exception_on_nonzero=False)
+        self.assertNotEqual(ret, 0)
+        # now we expect it to throw an exception
+        with self.assertRaises(Exception):
+            ret = utilities.RunPythonScript(bad_path, "", capture=False, workingdir=None,
+                                            raise_exception_on_nonzero=True)
+            self.assertNotEqual(ret, 0)
+
 
 # DO NOT PUT A MAIN FUNCTION HERE
 # this test runs itself to test runpython script, which is a tad bit strange yes.

--- a/edk2toollib/utility_functions_test.py
+++ b/edk2toollib/utility_functions_test.py
@@ -8,14 +8,13 @@
 ##
 
 import unittest
-import sys
 import os
 import edk2toollib.utility_functions as utilities
 
 
 class UtilityFunctionsTest(unittest.TestCase):
 
-    def test_RunPythonScript(self):  # simple run yourself!
+    def test_RunPythonScript(self):  # simple- run yourself!
         path = __file__
         working_dir = os.path.dirname(__file__)
         ret = utilities.RunPythonScript(path, "", working_dir)


### PR DESCRIPTION
an x was in front of raise_exception_on_nonzero, which caused an exception