### PR TITLE
Fix exclude pattern for code coverage config file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,4 @@
 [run]
-omit = *_tests.py
+omit = 
+    # test files should all be named *_test.py
+    */*_test.py


### PR DESCRIPTION
Code coverage calculation was including unittest code.  This change omits unittests that follow the naming standard of *_test.py. 