### PR TITLE
Make sure to do a case insensitive check on processor info

### DIFF
--- a/edk2toollib/utility_functions.py
+++ b/edk2toollib/utility_functions.py
@@ -103,7 +103,7 @@ def GetHostInfo():
     arch = None
     bit = None
 
-    if ("x86" in processor_info.lower()) or ("AMD" in processor_info.upper()) or ("Intel" in processor_info):
+    if ("x86" in processor_info.lower()) or ("AMD" in processor_info.upper()) or ("INTEL" in processor_info.upper()):
         arch = "x86"
     elif ("ARM" in processor_info.upper()) or ("AARCH" in processor_info.upper()):
         arch = "ARM"

--- a/edk2toollib/utility_functions.py
+++ b/edk2toollib/utility_functions.py
@@ -103,9 +103,9 @@ def GetHostInfo():
     arch = None
     bit = None
 
-    if ("x86" in processor_info) or ("AMD" in processor_info) or ("Intel" in processor_info):
+    if ("x86" in processor_info.lower()) or ("AMD" in processor_info.upper()) or ("Intel" in processor_info):
         arch = "x86"
-    elif ("ARM" in processor_info) or ("AARCH" in processor_info):
+    elif ("ARM" in processor_info.upper()) or ("AARCH" in processor_info.upper()):
         arch = "ARM"
 
     if "32" in processor_info:


### PR DESCRIPTION
On certain operating systems, the processor information is returned in lowercase (some return upper case). This goes to upper or lower as needed

Fixes #26 