### PR TITLE
[Fix] trim down on errors emitted from base_parser

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/base_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/base_parser.py
@@ -231,7 +231,7 @@ class BaseParser(object):
                 v = self.InputVars.get(token)
 
                 if(v is None):
-                    self.Logger.error("Unknown variable %s in  %s" % (token, line))
+                    self.Logger.info("Unknown variable %s in  %s" % (token, line))
                     # raise Exception("Invalid Variable Replacement", token)
                     # just skip it because we need to support ifdef
                 else:


### PR DESCRIPTION
The base parser currently emits a lot of errors due to missing variables and now that we don't filter as heavily, they need to be lowered to a more sensible level.