### PR TITLE
base_parser: Fix DSC !ifdef and !ifndef parsing

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/base_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/base_parser.py
@@ -274,11 +274,11 @@ class BaseParser(object):
             return True
 
         elif(tokens[0].lower() == "!ifdef"):
-            self.PushConditional((tokens[1].count("$") == 0))
+            self.PushConditional(not (self.LocalVars.get(tokens[1]) is None))
             return True
 
         elif(tokens[0].lower() == "!ifndef"):
-            self.PushConditional((tokens[1].count("$") > 0))
+            self.PushConditional(self.LocalVars.get(tokens[1]) is None)
             return True
 
         elif(tokens[0].lower() == "!else"):

--- a/edk2toollib/uefi/edk2/parsers/base_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/base_parser.py
@@ -274,7 +274,7 @@ class BaseParser(object):
             return True
 
         elif(tokens[0].lower() == "!ifdef"):
-            self.PushConditional(not (self.LocalVars.get(tokens[1]) is None))
+            self.PushConditional(self.LocalVars.get(tokens[1]) is not None)
             return True
 
         elif(tokens[0].lower() == "!ifndef"):


### PR DESCRIPTION
The syntax of an !ifdef and !ifndef statement does not
use the value of a define that uses $().  Instead, only
the name of the define is used.

Update the test for !ifdef and !ifndef to check if the
define name in token[1] is in LocalVar or not and push
the correct conditional value of True or False.

This change was tested locally with the edk2/NetworkPkg.
With this change, the defines "Defines" section of
NetworkPkg.ci.yaml can be emptied, and the default values
for all defines are correctly parsed.

Signed-off-by: Kinney <michael.d.kinney@intel.com>