### PR TITLE
[Bug] Fix for macro replacement

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/base_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/base_parser.py
@@ -228,14 +228,14 @@ class BaseParser(object):
             self.Logger.critical("Tried to pop an empty conditional stack.  Line Number %d" % self.CurrentLine)
             return self.ConditionalStack.pop()  # this should cause a crash but will give trace.
 
-    def _FindReplacementForToken(self, token):
+    def _FindReplacementForToken(self, token, replace_if_not_found=False):
 
         v = self.LocalVars.get(token)
 
         if(v is None):
             v = self.InputVars.get(token)
 
-        if(v is None):
+        if(v is None and replace_if_not_found):
             v = self._MacroNotDefinedValue
 
         if (type(v) is bool):
@@ -266,7 +266,7 @@ class BaseParser(object):
         tokens = result.split()
         if len(tokens) > 1 and tokens[0].lower() in ["!ifdef", "!ifndef"]:
             if not tokens[1].startswith("$("):
-                v = self._FindReplacementForToken(tokens[1])
+                v = self._FindReplacementForToken(tokens[1], replace_if_not_found=True)
                 result = result.replace(tokens[1], v, 1)
 
         # use line to avoid change by handling above

--- a/edk2toollib/uefi/edk2/parsers/base_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/base_parser.py
@@ -264,9 +264,11 @@ class BaseParser(object):
         # both syntax options can not be supported.
         result = line
         tokens = result.split()
+        replace = False
         if len(tokens) > 1 and tokens[0].lower() in ["!ifdef", "!ifndef"]:
+            replace = True
             if not tokens[1].startswith("$("):
-                v = self._FindReplacementForToken(tokens[1], replace_if_not_found=True)
+                v = self._FindReplacementForToken(tokens[1], replace)
                 result = result.replace(tokens[1], v, 1)
 
         # use line to avoid change by handling above
@@ -279,7 +281,7 @@ class BaseParser(object):
             token = line[start + 2:end]
             replacement_token = line[start:end + 1]
             self.Logger.debug("Token is %s" % token)
-            v = self._FindReplacementForToken(token)
+            v = self._FindReplacementForToken(token, replace)
             result = result.replace(replacement_token, v, 1)
 
             index = end + 1

--- a/edk2toollib/uefi/edk2/parsers/base_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/base_parser.py
@@ -267,7 +267,7 @@ class BaseParser(object):
         # both syntax options can not be supported.
         result = line
         tokens = result.split()
-        replace = len(tokens) > 1 and tokens[0].lower() in ["!ifdef", "!ifndef", "!if"]
+        replace = len(tokens) > 1 and tokens[0].lower() in ["!ifdef", "!ifndef", "!if", "!elseif"]
         if len(tokens) > 1 and tokens[0].lower() in ["!ifdef", "!ifndef"]:
             if not tokens[1].startswith("$("):
                 v = self._FindReplacementForToken(tokens[1], replace)

--- a/edk2toollib/uefi/edk2/parsers/base_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/base_parser.py
@@ -238,6 +238,9 @@ class BaseParser(object):
         if(v is None and replace_if_not_found):
             v = self._MacroNotDefinedValue
 
+        elif(v is None):
+            return None
+
         if (type(v) is bool):
             v = "true" if v else "false"
 
@@ -264,12 +267,12 @@ class BaseParser(object):
         # both syntax options can not be supported.
         result = line
         tokens = result.split()
-        replace = False
+        replace = len(tokens) > 1 and tokens[0].lower() in ["!ifdef", "!ifndef", "!if"]
         if len(tokens) > 1 and tokens[0].lower() in ["!ifdef", "!ifndef"]:
-            replace = True
             if not tokens[1].startswith("$("):
                 v = self._FindReplacementForToken(tokens[1], replace)
-                result = result.replace(tokens[1], v, 1)
+                if v is not None:
+                    result = result.replace(tokens[1], v, 1)
 
         # use line to avoid change by handling above
         rep = line.count("$")
@@ -282,7 +285,8 @@ class BaseParser(object):
             replacement_token = line[start:end + 1]
             self.Logger.debug("Token is %s" % token)
             v = self._FindReplacementForToken(token, replace)
-            result = result.replace(replacement_token, v, 1)
+            if v is not None:
+                result = result.replace(replacement_token, v, 1)
 
             index = end + 1
             rep = rep - 1

--- a/edk2toollib/uefi/edk2/parsers/base_parser_test.py
+++ b/edk2toollib/uefi/edk2/parsers/base_parser_test.py
@@ -113,6 +113,17 @@ class TestBaseParser(unittest.TestCase):
         line = "!IFnDEF name"
         self.assertEqual(parser.ReplaceVariables(line), "!IFnDEF sean")
 
+    def test_replace_macro_elseif(self):
+        parser = BaseParser("")
+        parser.SetInputVars({
+            "name": "matt"
+        })
+        line = "!elseif $(name)"
+        self.assertEqual(parser.ReplaceVariables(line), "!elseif matt")
+
+        line = "!ELSEIF $(Invalid_Token)"
+        self.assertEqual(parser.ReplaceVariables(line), "!ELSEIF 0")
+
     def test_conditional_ifdef(self):
         parser = BaseParser("")
 

--- a/edk2toollib/uefi/edk2/parsers/base_parser_test.py
+++ b/edk2toollib/uefi/edk2/parsers/base_parser_test.py
@@ -54,8 +54,8 @@ class TestBaseParser(unittest.TestCase):
         parser.SetInputVars({
             "name": "sean"
         })
-        line = "Hello $(Unknown_Token)!"
-        self.assertEqual(parser.ReplaceVariables(line), "Hello 0!")
+        line = "!if $(Unknown_Token)!"
+        self.assertEqual(parser.ReplaceVariables(line), "!if 0!")
 
     def test_replace_macro_ifdef_dollarsign(self):
         parser = BaseParser("")
@@ -427,7 +427,7 @@ class TestBaseParser(unittest.TestCase):
         self.assertEqual(no_var_result, no_var)
         # make sure we don't fail when we have unknown variables
         na_var = "unknown var $(UNKNOWN)"
-        na_var_after = "unknown var 0"
+        na_var_after = "unknown var $(UNKNOWN)"
         na_var_result = parser.ReplaceVariables(na_var)
         self.assertEqual(na_var_result, na_var_after)
         # make sure we're good for all the variables
@@ -455,7 +455,7 @@ class TestBaseParser(unittest.TestCase):
         self.assertEqual(no_var_result, no_var)
         # make sure we don't fail when we have unknown variables
         na_var = "unknown var $(UNKNOWN)"
-        na_var_after = "unknown var 0"
+        na_var_after = "unknown var $(UNKNOWN)"
         na_var_result = parser.ReplaceVariables(na_var)
         self.assertEqual(na_var_result, na_var_after)
         # make sure we're good for all the variables


### PR DESCRIPTION
Previously, when replacing variables, we would replace it with 0. This causes problems when we have dependencies on defines.

Fixes #58 