### PR TITLE
[Bug] Fix to seek_end in StringHandler

### DIFF
--- a/edk2toollib/log/string_handler.py
+++ b/edk2toollib/log/string_handler.py
@@ -6,10 +6,7 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 import logging
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+import io
 
 
 class StringStreamHandler(logging.StreamHandler):
@@ -17,7 +14,7 @@ class StringStreamHandler(logging.StreamHandler):
 
     def __init__(self):
         logging.Handler.__init__(self)
-        self.stream = StringIO()
+        self.stream = io.StringIO()
 
     def handle(self, record):
         """
@@ -44,7 +41,7 @@ class StringStreamHandler(logging.StreamHandler):
         self.stream.seek(0, 0)
 
     def seek_end(self):
-        self.stream.seek(2, 0)
+        self.stream.seek(0, io.SEEK_END)
 
     def seek(self, offset, whence):
         return self.stream.seek(offset, whence)

--- a/edk2toollib/log/string_handler_test.py
+++ b/edk2toollib/log/string_handler_test.py
@@ -1,0 +1,43 @@
+# @file string_handler_test.py
+# Contains unit test routines for the string_handler functions
+#
+#
+# Copyright (c) Microsoft Corporation
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+import unittest
+import logging
+import os
+from edk2toollib.log.string_handler import StringStreamHandler
+from edk2toollib.uefi.edk2.parsers.dsc_parser import DscParser
+
+
+class TestStringStreamHandler(unittest.TestCase):
+
+  def test_init(self):
+    handler = StringStreamHandler()
+    self.assertNotEqual(handler, None)
+
+  def create_record(self, message="TEST", level=logging.INFO, name=""):
+    return logging.LogRecord(name, level, __file__, 0, message, [], None)
+
+  def test_readlines(self):
+    # create the handler
+    handler = StringStreamHandler()
+    handler.setLevel(logging.DEBUG)
+    LINES_TO_DEBUG = 10
+    # create some records for it to process
+    for i in range(LINES_TO_DEBUG):
+      rec = self.create_record(f"test{i}")
+      handler.handle(rec)
+    # check to make sure we don't have any
+    self.assertEqual(len(handler.readlines()), 0, "We shouldn't have anything because our stream is at the end")
+    # go to the beginning and read the streams
+    handler.seek_start()
+    self.assertEqual(len(handler.readlines()), LINES_TO_DEBUG, "We should have at least a few")
+    # go to the beginning but then back to the end
+    handler.seek_start()
+    handler.seek_end()
+    self.assertEqual(len(handler.readlines()), 0, "We shouldn't have anything because our stream is at the end")

--- a/edk2toollib/log/string_handler_test.py
+++ b/edk2toollib/log/string_handler_test.py
@@ -11,33 +11,32 @@ import unittest
 import logging
 import os
 from edk2toollib.log.string_handler import StringStreamHandler
-from edk2toollib.uefi.edk2.parsers.dsc_parser import DscParser
 
 
 class TestStringStreamHandler(unittest.TestCase):
 
-  def test_init(self):
-    handler = StringStreamHandler()
-    self.assertNotEqual(handler, None)
+    def test_init(self):
+        handler = StringStreamHandler()
+        self.assertNotEqual(handler, None)
 
-  def create_record(self, message="TEST", level=logging.INFO, name=""):
-    return logging.LogRecord(name, level, __file__, 0, message, [], None)
+    def create_record(self, message="TEST", level=logging.INFO, name=""):
+        return logging.LogRecord(name, level, __file__, 0, message, [], None)
 
-  def test_readlines(self):
-    # create the handler
-    handler = StringStreamHandler()
-    handler.setLevel(logging.DEBUG)
-    LINES_TO_DEBUG = 10
-    # create some records for it to process
-    for i in range(LINES_TO_DEBUG):
-      rec = self.create_record(f"test{i}")
-      handler.handle(rec)
-    # check to make sure we don't have any
-    self.assertEqual(len(handler.readlines()), 0, "We shouldn't have anything because our stream is at the end")
-    # go to the beginning and read the streams
-    handler.seek_start()
-    self.assertEqual(len(handler.readlines()), LINES_TO_DEBUG, "We should have at least a few")
-    # go to the beginning but then back to the end
-    handler.seek_start()
-    handler.seek_end()
-    self.assertEqual(len(handler.readlines()), 0, "We shouldn't have anything because our stream is at the end")
+    def test_readlines(self):
+        # create the handler
+        handler = StringStreamHandler()
+        handler.setLevel(logging.DEBUG)
+        LINES_TO_DEBUG = 10
+        # create some records for it to process
+        for i in range(LINES_TO_DEBUG):
+            rec = self.create_record(f"test{i}")
+            handler.handle(rec)
+        # check to make sure we don't have any
+        self.assertEqual(len(handler.readlines()), 0, "We shouldn't have anything because our stream is at the end")
+        # go to the beginning and read the streams
+        handler.seek_start()
+        self.assertEqual(len(handler.readlines()), LINES_TO_DEBUG, "We should have at least a few")
+        # go to the beginning but then back to the end
+        handler.seek_start()
+        handler.seek_end()
+        self.assertEqual(len(handler.readlines()), 0, "We shouldn't have anything because our stream is at the end")

--- a/edk2toollib/log/string_handler_test.py
+++ b/edk2toollib/log/string_handler_test.py
@@ -9,7 +9,6 @@
 
 import unittest
 import logging
-import os
 from edk2toollib.log.string_handler import StringStreamHandler
 
 


### PR DESCRIPTION
Previously, we didn't correctly seek to the end in string handler, this was just never used. This also drops Python 2 support from this file, which we don't support