### PR TITLE
[Bug] don't do logging in GetHostInfo utility function

### DIFF
--- a/edk2toollib/utility_functions.py
+++ b/edk2toollib/utility_functions.py
@@ -98,7 +98,6 @@ def GetHostInfo():
     host_info = platform.uname()
     os = host_info.system
     processor_info = host_info.machine
-    logging.debug("Getting host info for host: {0}".format(str(host_info)))
 
     arch = None
     bit = None


### PR DESCRIPTION
We shouldn't do logging in GetHostInfo as it can be called before logging is fully up and running.