### PR TITLE
[bug] Fixed dec and dsc parser to explode less

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/dec_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/dec_parser.py
@@ -120,7 +120,7 @@ class PcdDeclarationEntry():
         op = sp[2].split("|")
 
         if(len(op) != 4):
-            raise Exception("Too many parts")
+            raise Exception("Too many parts " + rawtext)
 
         self.name = op[0].strip()
         self.default_value = op[1].strip()
@@ -153,6 +153,7 @@ class DecParser(HashFileParser):
         InGuidsSection = False
         InPPISection = False
         InPcdSection = False
+        InExtendedPcd = False
         InIncludesSection = False
 
         for line in self.Lines:
@@ -199,6 +200,17 @@ class DecParser(HashFileParser):
             elif InPcdSection:
                 if sline.strip()[0] == '[':
                     InPcdSection = False
+                elif sline.strip().endswith("{"):
+                    t = PcdDeclarationEntry(self.PackageName, sline)
+                    InExtendedPcd = True
+                    continue
+                elif sline.strip().endswith("}"):
+                    InExtendedPcd = False
+                    self.Pcds.append(t)
+                    continue
+                elif InExtendedPcd:
+                    # TODO do something with the extended values we get
+                    continue
                 else:
                     t = PcdDeclarationEntry(self.PackageName, sline)
                     self.Pcds.append(t)

--- a/edk2toollib/uefi/edk2/parsers/dsc_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/dsc_parser.py
@@ -259,12 +259,16 @@ class DscParser(HashFileParser):
         f = open(os.path.join(filepath), "r")
         # expand all the lines and include other files
         file_lines = f.readlines()
-        self.__ProcessDefines(file_lines)
-        # reset the parser state before processing more
-        self.ResetParserState()
-        self.__ProcessMore(file_lines, file_name=os.path.join(filepath))
-        f.close()
-        self.Parsed = True
+        try:
+            self.__ProcessDefines(file_lines)
+            # reset the parser state before processing more
+            self.ResetParserState()
+            self.__ProcessMore(file_lines, file_name=os.path.join(filepath))
+            f.close()
+            self.Parsed = True
+        except Exception as e:
+            self.Logger.warning(f"{__name__} failed to parse: {filepath}")
+            self.Logger.info(e)
 
     def GetMods(self):
         return self.ThreeMods + self.SixMods


### PR DESCRIPTION
Previously, when the dec or dsc parser encounters an error, it explodes. Previously the API didn't really expect callers to handle exceptions.