### PR TITLE
edk2toollib/base_parser: Fix IN operator and quoted arguments

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/base_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/base_parser.py
@@ -140,7 +140,10 @@ class BaseParser(object):
         except ValueError:
             pass
         try:
-            ivalue2 = self.ConvertToInt(ivalue2)
+            if(cond.lower() == "in"):
+                ivalue2 = set(ivalue2.split())
+            else:
+                ivalue2 = self.ConvertToInt(ivalue2)
         except ValueError:
             pass
 
@@ -153,7 +156,7 @@ class BaseParser(object):
             # not equal
             return (ivalue != ivalue2) and (value != value2)
 
-        elif (cond == "in"):
+        elif (cond.lower() == "in"):
             # contains
             return value in value2
 
@@ -311,7 +314,11 @@ class BaseParser(object):
         Returns:
 
         """
-        tokens = text.split()
+        if '"' in text:
+            tokens = text.split('"')
+            tokens = tokens[0].split() + [tokens[1]] + tokens[2].split()
+        else:
+            tokens = text.split()
         if(tokens[0].lower() == "!if"):
             # need to add support for OR/AND
             if (len(tokens) == 2):


### PR DESCRIPTION
Update the Base Parser to support a DSC file conditional
statement such as the following:

!if $(CRYPTO_SERVICES) IN "ALL NONE MIN_PEI MIN_DXE_MIN_SMM"

One of the arguments is a quoted string that needs to be
parsed as a single argument.

The IN operator tests for membership.  Update parser to support
upper a lower case forms of the IN operator and use the
python set() type to test for membership if the IN operator
is being evaluated.

#72 

Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>