### PR TITLE
Add /uselocaltime flag to Inf2Cat

### DIFF
--- a/edk2toollib/windows/capsule/cat_generator.py
+++ b/edk2toollib/windows/capsule/cat_generator.py
@@ -71,7 +71,7 @@ class CatGenerator(object):
 
         OutputFolder = os.path.dirname(OutputCatFile)
         # Make Cat file
-        cmd = "/driver:. /os:" + self.OperatingSystem + "_" + self.Arch + " /verbose"
+        cmd = "/driver:. /os:" + self.OperatingSystem + "_" + self.Arch + " /verbose /uselocaltime"
         ret = RunCmd(PathToInf2CatTool, cmd, workingdir=OutputFolder)
         if(ret != 0):
             raise Exception("Creating Cat file Failed with errorcode %d" % ret)


### PR DESCRIPTION
Inf2Cat generation in cat_generator was failing in geographies where localtime is ahead of UTC with "DriverVer set to a date in the future" error message. Since the rest of capsule generation uses local time, https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/inf2cat recommends using /uselocaltime flag to Inf2Cat to avoid this issue. 