### PR TITLE
Change Enum to Python 3

### DIFF
--- a/edk2toollib/utility_functions.py
+++ b/edk2toollib/utility_functions.py
@@ -38,10 +38,9 @@ def Enum(*args):
     calling_mod = inspect.getmodule(calling_frame[0])
     calling_func = calling_frame.function
     calling_line = calling_frame.lineno
-    
+
     enum_name = calling_func + ":" + str(calling_line)
-    print('Caller name: ', calling_func)
-    print("Module: ", calling_mod)
+    logging.warning(f"Enum is deprecated! Please fix it in {calling_mod}:{calling_func}")
     return StdEnum(enum_name, items, module=calling_mod)
 
 

--- a/edk2toollib/utility_functions.py
+++ b/edk2toollib/utility_functions.py
@@ -19,16 +19,30 @@ import inspect
 import platform
 import importlib
 from collections import namedtuple
-
-####
-# Helper to allow Enum type to be used which allows better code readability
-#
-# ref: http://stackoverflow.com/questions/36932/how-can-i-represent-an-enum-in-python
-####
+from enum import Enum as StdEnum
 
 
-class Enum(tuple):
-    __getattr__ = tuple.index
+def Enum(*args):
+    items = []
+    if len(args) == 1:
+        item = args[0]
+        if isinstance(item, list):
+            items = item
+        elif isinstance(item, tuple):
+            items = list(item)
+        else:
+            items.append(item)
+    else:
+        items = args
+    calling_frame = inspect.stack()[1]
+    calling_mod = inspect.getmodule(calling_frame[0])
+    calling_func = calling_frame.function
+    calling_line = calling_frame.lineno
+    
+    enum_name = calling_func + ":" + str(calling_line)
+    print('Caller name: ', calling_func)
+    print("Module: ", calling_mod)
+    return StdEnum(enum_name, items, module=calling_mod)
 
 
 ####

--- a/edk2toollib/utility_functions.py
+++ b/edk2toollib/utility_functions.py
@@ -177,13 +177,15 @@ def RunCmd(cmd, parameters, capture=True, workingdir=None, outfile=None, outstre
     endtime = datetime.datetime.now()
     delta = endtime - starttime
     endtime_str = "{0[0]:02}:{0[1]:02}".format(divmod(delta.seconds, 60))
+    returncode_str = "{0:#010x}".format(c.returncode)
     logging.log(logging_level, "------------------------------------------------")
     logging.log(logging_level, "--------------Cmd Output Finished---------------")
     logging.log(logging_level, "--------- Running Time (mm:ss): " + endtime_str + " ----------")
+    logging.log(logging_level, "----------- Return Code: " + returncode_str + " ------------")
     logging.log(logging_level, "------------------------------------------------")
 
     if raise_exception_on_nonzero and c.returncode != 0:
-        raise Exception("{0} failed with error code: {1}".format(cmd, c.returncode))
+        raise Exception("{0} failed with Return Code: {1}".format(cmd, returncode_str))
     return c.returncode
 
 ####

--- a/edk2toollib/utility_functions_test.py
+++ b/edk2toollib/utility_functions_test.py
@@ -65,5 +65,32 @@ class UtilityFunctionsTest(unittest.TestCase):
         self.assertEqual(found_class, GrandChildOfDesiredClass)
 
 
+class EnumClassTest(unittest.TestCase):
+    def test_EnumClass_array(self):
+        all_animals = ["Dog", "Cat", "Rabbit"]
+        animals = utilities.Enum(all_animals)
+        
+        # make sure we have three animals
+        self.assertEqual(len(animals), 3)
+        self.assertTrue(hasattr(animals, "Dog"))
+        self.assertFalse(hasattr(animals, "Rat"))
+        self.assertFalse(hasattr(animals, "dog"))
+        # check to make sure the values are unique
+        self.assertNotEqual(animals.Dog, animals.Cat)
+
+        # make sure we can iterate over the members
+        for animal in animals.__members__:
+            self.assertIn(animal, all_animals)
+
+
+    def test_EnumClass_args(self):
+        colors = utilities.Enum("Green", "Blue", "Red", "Yellow")
+        # make sure we have four colors
+        self.assertEqual(len(colors), 4)
+        self.assertTrue(hasattr(colors, "Red"))
+        self.assertFalse(hasattr(colors, "Purple"))
+        # check to make sure the values are unique
+        self.assertNotEqual(colors.Green, colors.Red)
+
 # DO NOT PUT A MAIN FUNCTION HERE
 # this test runs itself to test runpython script, which is a tad bit strange yes.

--- a/edk2toollib/utility_functions_test.py
+++ b/edk2toollib/utility_functions_test.py
@@ -69,7 +69,7 @@ class EnumClassTest(unittest.TestCase):
     def test_EnumClass_array(self):
         all_animals = ["Dog", "Cat", "Rabbit"]
         animals = utilities.Enum(all_animals)
-        
+
         # make sure we have three animals
         self.assertEqual(len(animals), 3)
         self.assertTrue(hasattr(animals, "Dog"))
@@ -81,7 +81,6 @@ class EnumClassTest(unittest.TestCase):
         # make sure we can iterate over the members
         for animal in animals.__members__:
             self.assertIn(animal, all_animals)
-
 
     def test_EnumClass_args(self):
         colors = utilities.Enum("Green", "Blue", "Red", "Yellow")


### PR DESCRIPTION
Python 3.4+ includes support for real enums. 
This class is offered as a compatibility shim.