### PR TITLE
[BugFix] updated the parser to handle structured pcd declarations

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/dec_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/dec_parser.py
@@ -118,18 +118,20 @@ class PcdDeclarationEntry():
         sp = rawtext.partition(".")
         self.token_space_name = sp[0].strip()
         op = sp[2].split("|")
-
-        if(len(op) < 4):
-            raise Exception("Too few parts")
-        if(len(op) > 5):
-            raise Exception("Too many parts")
-        if(len(op) == 5 and op[4].strip() != '{'):
-            raise Exception("Too many parts")
+        # if it's less than 4, less 
+        if(len(op) == 2 and op[0].count(".") > 0):
+            pass
+        elif(len(op) < 4):
+            raise Exception(f"Too few parts: {op}")
+        elif(len(op) > 5):
+            raise Exception(f"Too many parts: {rawtext}")
+        elif(len(op) == 5 and op[4].strip() != '{'):
+            raise Exception(f"Too many parts: {rawtext}")
 
         self.name = op[0].strip()
         self.default_value = op[1].strip()
-        self.type = op[2].strip()
-        self.id = op[3].strip()
+        self.type = op[2].strip() if len(op) > 2 else "STRUCTURED_PCD"
+        self.id = op[3].strip() if len(op) > 2 else "STRUCTURED_PCD"
 
 
 class DecParser(HashFileParser):

--- a/edk2toollib/uefi/edk2/parsers/dec_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/dec_parser.py
@@ -118,7 +118,7 @@ class PcdDeclarationEntry():
         sp = rawtext.partition(".")
         self.token_space_name = sp[0].strip()
         op = sp[2].split("|")
-        # if it's less than 4, less 
+        # if it's less than 4, less
         if(len(op) == 2 and op[0].count(".") > 0):
             pass
         elif(len(op) < 4):

--- a/edk2toollib/uefi/edk2/parsers/dec_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/dec_parser.py
@@ -118,11 +118,13 @@ class PcdDeclarationEntry():
         sp = rawtext.partition(".")
         self.token_space_name = sp[0].strip()
         op = sp[2].split("|")
-        # if it's less than 4, less
+        # if it's 2 long, we need to check that it's a structured PCD
         if(len(op) == 2 and op[0].count(".") > 0):
             pass
+        # otherwise it needs at least 4 parts
         elif(len(op) < 4):
             raise Exception(f"Too few parts: {op}")
+        # but also less than 5
         elif(len(op) > 5):
             raise Exception(f"Too many parts: {rawtext}")
         elif(len(op) == 5 and op[4].strip() != '{'):
@@ -130,6 +132,7 @@ class PcdDeclarationEntry():
 
         self.name = op[0].strip()
         self.default_value = op[1].strip()
+        # if we don't know what the type and id, it's because it's structured
         self.type = op[2].strip() if len(op) > 2 else "STRUCTURED_PCD"
         self.id = op[3].strip() if len(op) > 2 else "STRUCTURED_PCD"
 

--- a/edk2toollib/uefi/edk2/parsers/dec_parser_test.py
+++ b/edk2toollib/uefi/edk2/parsers/dec_parser_test.py
@@ -95,6 +95,17 @@ class TestPcdDeclarationEntry(unittest.TestCase):
         SAMPLE_DATA_DECL = """garbage.garbageNAME|FALSE|BOOLEAN|0x0001001d|morestuff|questions|this|should|fail"""
         with self.assertRaises(Exception):
             PcdDeclarationEntry("testpkg", SAMPLE_DATA_DECL)
+    
+    def test_good_structured_input(self):
+        SAMPLE_DATA_DECL = """gSomePkgTokenSpaceGuid.PcdThatInformation.Subfield|0x1"""
+        a = PcdDeclarationEntry("testpkg", SAMPLE_DATA_DECL)
+        self.assertEqual(a.token_space_name, "gSomePkgTokenSpaceGuid")
+        self.assertEqual(a.name, "PcdThatInformation.Subfield")
+        
+    def test_bad_structured_input(self):
+        SAMPLE_DATA_DECL = """gSomePkgTokenSpaceGuid.PcdThatInformation|0x1"""
+        with self.assertRaises(Exception):
+            PcdDeclarationEntry("testpkg", SAMPLE_DATA_DECL)
 
 
 class TestDecParser(unittest.TestCase):

--- a/edk2toollib/uefi/edk2/parsers/dec_parser_test.py
+++ b/edk2toollib/uefi/edk2/parsers/dec_parser_test.py
@@ -95,13 +95,13 @@ class TestPcdDeclarationEntry(unittest.TestCase):
         SAMPLE_DATA_DECL = """garbage.garbageNAME|FALSE|BOOLEAN|0x0001001d|morestuff|questions|this|should|fail"""
         with self.assertRaises(Exception):
             PcdDeclarationEntry("testpkg", SAMPLE_DATA_DECL)
-    
+
     def test_good_structured_input(self):
         SAMPLE_DATA_DECL = """gSomePkgTokenSpaceGuid.PcdThatInformation.Subfield|0x1"""
         a = PcdDeclarationEntry("testpkg", SAMPLE_DATA_DECL)
         self.assertEqual(a.token_space_name, "gSomePkgTokenSpaceGuid")
         self.assertEqual(a.name, "PcdThatInformation.Subfield")
-        
+
     def test_bad_structured_input(self):
         SAMPLE_DATA_DECL = """gSomePkgTokenSpaceGuid.PcdThatInformation|0x1"""
         with self.assertRaises(Exception):


### PR DESCRIPTION
The DEC parser will throw errors when parsing DEC's that contain things like 
`gAdvancedFeaturePkgTokenSpaceGuid.PcdSmbiosType0BiosInformation.Vendor|0x1`