### PR TITLE
Support error or warning configuration for Edk2Path object

### DIFF
--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -219,20 +219,15 @@ class Edk2Path(object):
         # make sure filesystem has file or at least folder
         if not os.path.isfile(InputPath):
             logging.debug("InputPath doesn't exist in filesystem")
-        if not os.path.isdir(os.path.dirname(os.path.dirname(InputPath))):
-            logging.warning("InputPath parent parent directory doesn't exist in filesystem")
-            return []
-        if not os.path.isdir(os.path.dirname(InputPath)):
-            logging.warning("InputPath parent directory doesn't exist in filesystem")
-            return []
 
         modules = []
         # Check current dir
         dirpath = os.path.dirname(InputPath)
-        for f in os.listdir(dirpath):
-            if fnmatch.fnmatch(f.lower(), '*.inf'):
-                self.logger.debug("Found INF file in %s.  INf is: %s", dirpath, f)
-                modules.append(os.path.join(dirpath, f))
+        if os.path.isdir(dirpath):
+            for f in os.listdir(dirpath):
+                if fnmatch.fnmatch(f.lower(), '*.inf'):
+                    self.logger.debug("Found INF file in %s.  INf is: %s", dirpath, f)
+                    modules.append(os.path.join(dirpath, f))
 
         # if didn't find any in current dir go to parent dir.
         # this handles cases like:
@@ -243,9 +238,10 @@ class Edk2Path(object):
         #
         if(len(modules) == 0):
             dirpath = os.path.dirname(dirpath)
-            for f in os.listdir(dirpath):
-                if fnmatch.fnmatch(f.lower(), '*.inf'):
-                    self.logger.debug("Found INF file in %s.  INf is: %s", dirpath, f)
-                    modules.append(os.path.join(dirpath, f))
+            if os.path.isdir(dirpath):
+                for f in os.listdir(dirpath):
+                    if fnmatch.fnmatch(f.lower(), '*.inf'):
+                        self.logger.debug("Found INF file in %s.  INf is: %s", dirpath, f)
+                        modules.append(os.path.join(dirpath, f))
 
         return modules

--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -8,7 +8,7 @@
 import os
 import logging
 import fnmatch
-from typing import Iterable, Tuple
+from typing import Iterable
 
 #
 # Class to help convert from absolute path to EDK2 build path
@@ -18,13 +18,13 @@ from typing import Iterable, Tuple
 
 class Edk2Path(object):
 
-
     def __init__(self, ws: os.PathLike, packagepathlist: Iterable[os.PathLike], error_on_invalid_pp: bool = True):
         """ An Edk2Path object is an object that can be used to resolve edk2 relative paths
 
         Args:
             ws: absolute path or cwd relative path of the workspace.
-            packagespathlist: list of packages path.  Entries can be Absolute path, workspace relative path, or CWD relative.
+            packagespathlist: list of packages path.
+                Entries can be Absolute path, workspace relative path, or CWD relative.
             error_on_invalid_pp: default value is True. If packages path value is invalid raise exception
         """
 
@@ -54,8 +54,9 @@ class Edk2Path(object):
         error = False
         for a in self.PackagePathList[:]:
             if(not os.path.isdir(a)):
-                self.logger.log(logging.ERROR if error_on_invalid_pp else logging.WARNING, "Invalid package path entry {0}".format(a))
-                self.PackagePathList.remove(a) # remove invalid path
+                self.logger.log(logging.ERROR if error_on_invalid_pp else logging.WARNING,
+                                "Invalid package path entry {0}".format(a))
+                self.PackagePathList.remove(a)  # remove invalid path
                 error = True
 
         # report error
@@ -224,7 +225,6 @@ class Edk2Path(object):
         if not os.path.isdir(os.path.dirname(InputPath)):
             logging.warning("InputPath parent directory doesn't exist in filesystem")
             return []
-
 
         modules = []
         # Check current dir

--- a/edk2toollib/uefi/edk2/path_utilities_test.py
+++ b/edk2toollib/uefi/edk2/path_utilities_test.py
@@ -108,7 +108,6 @@ class PathUtilitiesTest(unittest.TestCase):
         pathobj = Edk2Path(self.tmp, [pp], error_on_invalid_pp=False)
         self.assertEqual(len(pathobj.PackagePathList), 0)
 
-
     def test_pp_inside_workspace(self):
         ''' test with packagespath pointing to folder nested inside workspace
         root/                   <-- current working directory

--- a/edk2toollib/uefi/edk2/path_utilities_test.py
+++ b/edk2toollib/uefi/edk2/path_utilities_test.py
@@ -104,6 +104,10 @@ class PathUtilitiesTest(unittest.TestCase):
         # relative path
         with self.assertRaises(Exception):
             Edk2Path(self.tmp, [pp])
+        # confirm optional parameter to remove invalid pp values
+        pathobj = Edk2Path(self.tmp, [pp], error_on_invalid_pp=False)
+        self.assertEqual(len(pathobj.PackagePathList), 0)
+
 
     def test_pp_inside_workspace(self):
         ''' test with packagespath pointing to folder nested inside workspace

--- a/edk2toollib/uefi/edk2/path_utilities_test.py
+++ b/edk2toollib/uefi/edk2/path_utilities_test.py
@@ -466,10 +466,27 @@ class PathUtilitiesTest(unittest.TestCase):
         self.assertEqual(len(relist), 1)
         self.assertIn(os.path.join(pp_pkg_abs, "module1", "module1.INF"), relist)
 
-        # file in packages path root - no package- should return packages path dir
+        # file in packages path root - no module
         p = os.path.join(folder_pp1_abs, "testfile.c")
         relist = pathobj.GetContainingModules(p)
         self.assertEqual(len(relist), 0)
+
+        # file doesn't exist and parent folder doesn't exist
+        p = os.path.join(ws_pkg_abs, "ThisParentDirDoesntExist", "ThisFileDoesntExist.c")
+        relist = pathobj.GetContainingModules(p)
+        self.assertEqual(len(relist), 0)
+
+        # file doesn't exist and parent folder doesn't exist and parent parent folder doesn't exist
+        p = os.path.join(ws_pkg_abs, "DirDirDoesntExist", "DirDoesntExist", "FileDoesntExist.c")
+        relist = pathobj.GetContainingModules(p)
+        self.assertEqual(len(relist), 0)
+
+        # file doesn't exist and parent folder doesn't exist but parent parent is valid module
+        # file in module in WSTestPkg/module1/module1.inf
+        p = os.path.join(ws_pkg_abs, "module1", "ThisParentDirDoesntExist", "testfile.c")
+        relist = pathobj.GetContainingModules(p)
+        self.assertEqual(len(relist), 1)
+        self.assertIn(os.path.join(ws_pkg_abs, "module1", "module1.inf"), relist)
 
     def test_get_edk2_relative_path_from_absolute_path(self):
         ''' test basic usage of GetEdk2RelativePathFromAbsolutePath with packages path nested

--- a/edk2toollib/uefi/edk2/path_utilities_test.py
+++ b/edk2toollib/uefi/edk2/path_utilities_test.py
@@ -472,18 +472,18 @@ class PathUtilitiesTest(unittest.TestCase):
         self.assertEqual(len(relist), 0)
 
         # file doesn't exist and parent folder doesn't exist
-        p = os.path.join(ws_pkg_abs, "ThisParentDirDoesntExist", "ThisFileDoesntExist.c")
+        p = os.path.join(ws_pkg_abs, "ThisParentDirDoesNotExist", "ThisFileDoesNotExist.c")
         relist = pathobj.GetContainingModules(p)
         self.assertEqual(len(relist), 0)
 
         # file doesn't exist and parent folder doesn't exist and parent parent folder doesn't exist
-        p = os.path.join(ws_pkg_abs, "DirDirDoesntExist", "DirDoesntExist", "FileDoesntExist.c")
+        p = os.path.join(ws_pkg_abs, "DirDirDoesNotExist", "DirDoesNotExist", "FileDoesNotExist.c")
         relist = pathobj.GetContainingModules(p)
         self.assertEqual(len(relist), 0)
 
         # file doesn't exist and parent folder doesn't exist but parent parent is valid module
         # file in module in WSTestPkg/module1/module1.inf
-        p = os.path.join(ws_pkg_abs, "module1", "ThisParentDirDoesntExist", "testfile.c")
+        p = os.path.join(ws_pkg_abs, "module1", "ThisParentDirDoesNotExist", "testfile.c")
         relist = pathobj.GetContainingModules(p)
         self.assertEqual(len(relist), 1)
         self.assertIn(os.path.join(ws_pkg_abs, "module1", "module1.inf"), relist)


### PR DESCRIPTION
For scenarios where the full packages path list might include invalid paths due to an incomplete code tree allow the caller to set 'error_on_invalid_pp' parameter to false.  This will remove the packagespath entries that not valid and will not generate an error.  