### PR TITLE
Modify utility_functions reader() implementation to be more permissive

### DIFF
--- a/edk2toollib/utility_functions.py
+++ b/edk2toollib/utility_functions.py
@@ -162,6 +162,8 @@ def timing(f):
 # @param logging_level - log level to log output at.  Default is INFO
 # @param raise_exception_on_nonzero - Setting to true causes exception to be raised if the cmd
 #                                     return code is not zero.
+# @param encodingErrors - may be given to set the desired error handling for encoding errors decoding cmd output.
+#                         Default is 'strict'.
 #
 # @return returncode of called cmd
 ####

--- a/edk2toollib/utility_functions.py
+++ b/edk2toollib/utility_functions.py
@@ -79,14 +79,14 @@ class PropagatingThread(threading.Thread):
 #
 #  http://stackoverflow.com/questions/19423008/logged-subprocess-communicate
 ####
-def reader(filepath, outstream, stream, logging_level=logging.INFO):
+def reader(filepath, outstream, stream, logging_level=logging.INFO, encodingErrors='strict'):
     f = None
     # open file if caller provided path
     if(filepath):
         f = open(filepath, "w")
 
     while True:
-        s = stream.readline().decode(errors='ignore')
+        s = stream.readline().decode(errors=encodingErrors)
         if not s:
             break
         if(f is not None):
@@ -166,7 +166,7 @@ def timing(f):
 # @return returncode of called cmd
 ####
 def RunCmd(cmd, parameters, capture=True, workingdir=None, outfile=None, outstream=None, environ=None,
-           logging_level=logging.INFO, raise_exception_on_nonzero=False):
+           logging_level=logging.INFO, raise_exception_on_nonzero=False, encodingErrors='strict'):
     cmd = cmd.strip('"\'')
     if " " in cmd:
         cmd = '"' + cmd + '"'
@@ -180,7 +180,7 @@ def RunCmd(cmd, parameters, capture=True, workingdir=None, outfile=None, outstre
     logging.log(logging_level, "------------------------------------------------")
     c = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=workingdir, shell=True, env=environ)
     if(capture):
-        thread = PropagatingThread(target=reader, args=(outfile, outstream, c.stdout, logging_level))
+        thread = PropagatingThread(target=reader, args=(outfile, outstream, c.stdout, logging_level, encodingErrors))
         thread.start()
         c.wait()
         thread.join()

--- a/edk2toollib/utility_functions.py
+++ b/edk2toollib/utility_functions.py
@@ -86,7 +86,7 @@ def reader(filepath, outstream, stream, logging_level=logging.INFO):
         f = open(filepath, "w")
 
     while True:
-        s = stream.readline().decode()
+        s = stream.readline().decode(errors='ignore')
         if not s:
             break
         if(f is not None):


### PR DESCRIPTION
Modify utility_functions reader() implementation to be more permissive in the face of unexpected encoding coming from utilities executed with RunCmd()