### PR TITLE
windows/capsule: Update InfGenerator with integrity file

### DIFF
--- a/edk2toollib/windows/capsule/inf_generator.py
+++ b/edk2toollib/windows/capsule/inf_generator.py
@@ -14,6 +14,14 @@ import re
 import uuid
 
 
+class InfSection(object):
+    def __init__(self, name) -> None:
+        self.Name = name
+        self.Items = []
+
+    def __str__(self) -> str:
+        return "\n".join(["[%s]" % self.Name] + self.Items)
+
 class InfGenerator(object):
 
     ### INF Template ###
@@ -40,22 +48,17 @@ CatalogFile={Name}.cat
 [Firmware_Install.NT]
 CopyFiles = Firmware_CopyFiles
 {Rollback}
-[Firmware_CopyFiles]
-{FirmwareBinFile}
+{FirmwareCopyFilesSection}
 
 [Firmware_Install.NT.Hw]
 AddReg = Firmware_AddReg
 
-[Firmware_AddReg]
-HKR,,FirmwareId,,{{{EsrtGuid}}}
-HKR,,FirmwareVersion,%REG_DWORD%,{VersionHexString}
-HKR,,FirmwareFilename,,{FirmwareBinFile}
+{FirmwareAddRegSection}
 
 [SourceDisksNames]
 1 = %DiskName%
 
-[SourceDisksFiles]
-{FirmwareBinFile} = 1
+{SourceDisksFilesSection}
 
 [DestinationDirs]
 DefaultDestDir = %DIRID_WINDOWS%,Firmware ; %SystemRoot%\Firmware
@@ -74,10 +77,10 @@ REG_DWORD     = 0x00010001
 
     ROLLBACKTEMPLATE = r"""AddReg    = Firmware_DowngradePolicy_Addreg
 
-  ;override firmware resource update policy to allow downgrade to lower version
-  [Firmware_DowngradePolicy_Addreg]
-  HKLM,SYSTEM\CurrentControlSet\Control\FirmwareResources\{{{EsrtGuid}}},Policy,%REG_DWORD%,1
-  """
+;override firmware resource update policy to allow downgrade to lower version
+[Firmware_DowngradePolicy_Addreg]
+HKLM,SYSTEM\CurrentControlSet\Control\FirmwareResources\{{{EsrtGuid}}},Policy,%REG_DWORD%,1
+"""
 
     SUPPORTED_ARCH = {'amd64': 'amd64',
                       'x64': 'amd64',
@@ -96,6 +99,7 @@ REG_DWORD     = 0x00010001
         self.VersionHex = version_hex
         self._manufacturer = None  # default for optional feature
         self._date = datetime.date.today()
+        self._integrityfile = None
 
     @property
     def Name(self):
@@ -192,6 +196,14 @@ REG_DWORD     = 0x00010001
             raise ValueError("Date must be a datetime.date object")
         self._date = value
 
+    @property
+    def IntegrityFilename(self):
+        return str(self._integrityfile) if self._integrityfile is not None else ""
+
+    @IntegrityFilename.setter
+    def IntegrityFilename(self, value):
+        self._integrityfile = value
+
     def MakeInf(self, OutputInfFilePath, FirmwareBinFileName, Rollback=False):
         RollbackString = ""
         if(Rollback):
@@ -199,18 +211,36 @@ REG_DWORD     = 0x00010001
 
         binfilename = os.path.basename(FirmwareBinFileName)
 
+        copy_files = InfSection('Firmware_CopyFiles')
+        copy_files.Items.append(binfilename)
+
+        add_reg = InfSection('Firmware_AddReg')
+        add_reg.Items.append("HKR,,FirmwareId,,{{{guid}}}".format(guid=self.EsrtGuid))
+        add_reg.Items.append("HKR,,FirmwareVersion,%REG_DWORD%,{version}".format(
+            version=self.VersionHex))
+        add_reg.Items.append("HKR,,FirmwareFilename,,{file_name}".format(file_name=binfilename))
+
+        disks_files = InfSection('SourceDisksFiles')
+        disks_files.Items.append("{file_name} = 1".format(file_name=binfilename))
+
+        if self.IntegrityFilename != "":
+            copy_files.Items.append(self.IntegrityFilename)
+            add_reg.Items.append("HKR,,FirmwareIntegrityFilename,,{file_name}".format(file_name=self.IntegrityFilename))
+            disks_files.Items.append("{file_name} = 1".format(file_name=self.IntegrityFilename))
+
         Content = InfGenerator.TEMPLATE.format(
             Name=self.Name,
             Date=self.Date,
             Arch=self.Arch,
             DriverVersion=self.VersionString,
             EsrtGuid=self.EsrtGuid,
-            FirmwareBinFile=binfilename,
-            VersionHexString=self.VersionHex,
             Provider=self.Provider,
             MfgName=self.Manufacturer,
             Description=self.Description,
-            Rollback=RollbackString)
+            Rollback=RollbackString,
+            FirmwareCopyFilesSection=copy_files,
+            FirmwareAddRegSection=add_reg,
+            SourceDisksFilesSection=disks_files)
 
         with open(OutputInfFilePath, "w") as f:
             f.write(Content)

--- a/edk2toollib/windows/capsule/inf_generator.py
+++ b/edk2toollib/windows/capsule/inf_generator.py
@@ -22,6 +22,7 @@ class InfSection(object):
     def __str__(self) -> str:
         return "\n".join(["[%s]" % self.Name] + self.Items)
 
+
 class InfGenerator(object):
 
     ### INF Template ###

--- a/edk2toollib/windows/capsule/inf_generator_test.py
+++ b/edk2toollib/windows/capsule/inf_generator_test.py
@@ -58,7 +58,8 @@ class InfGeneratorTest(unittest.TestCase):
     def test_file(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             inffile_path = os.path.join(tmpdir, "InfFile.inf")
-            infgen = InfGenerator('TestName', 'TestProvider', InfGeneratorTest.VALID_GUID_STRING, "x64", "Test Description", "1.2.3.4", "0x01020304")
+            infgen = InfGenerator('TestName', 'TestProvider', InfGeneratorTest.VALID_GUID_STRING,
+                                  "x64", "Test Description", "1.2.3.4", "0x01020304")
             infgen.MakeInf(inffile_path, "TestFirmwareRom.bin", False)
 
             with open(inffile_path, "r") as inffile:
@@ -67,6 +68,24 @@ class InfGeneratorTest(unittest.TestCase):
                 file_contents = file_contents.replace("\n", "").replace("\t", "").replace(" ", "")
                 test_contents = TEST_FILE_CONTENTS.replace("\n", "").replace("\t", "").replace(" ", "")
                 self.assertEqual(test_contents, file_contents)
+
+    def test_integrity_file_entry(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            inffile_path = os.path.join(tmpdir, "InfFile.inf")
+            infgen = InfGenerator('TestName', 'TestProvider', InfGeneratorTest.VALID_GUID_STRING,
+                                  "x64", "Test Description", "1.2.3.4", "0x01020304")
+            infgen.MakeInf(inffile_path, "TestFirmwareRom.bin", False)
+            with open(inffile_path, "r") as inffile:
+                file_contents = inffile.read()
+                self.assertNotIn("SampleIntegrityFile.bin", file_contents)
+                self.assertNotIn("FirmwareIntegrityFilename", file_contents)
+
+            infgen.IntegrityFilename = "SampleIntegrityFile.bin"
+            infgen.MakeInf(inffile_path, "TestFirmwareRom.bin", False)
+            with open(inffile_path, "r") as inffile:
+                file_contents = inffile.read()
+                self.assertIn("SampleIntegrityFile.bin", file_contents)
+                self.assertIn("FirmwareIntegrityFilename", file_contents)
 
     def test_invalid_name_symbol(self):
 
@@ -151,7 +170,7 @@ HKR,,FirmwareFilename,,TestFirmwareRom.bin
 TestFirmwareRom.bin = 1
 
 [DestinationDirs]
-DefaultDestDir = %DIRID_WINDOWS%,Firmware ; %SystemRoot%\Firmware
+DefaultDestDir = %DIRID_WINDOWS%,Firmware ; %SystemRoot%\\Firmware
 
 [Strings]
 ; localizable

--- a/edk2toollib/windows/capsule/inf_generator_test.py
+++ b/edk2toollib/windows/capsule/inf_generator_test.py
@@ -7,7 +7,26 @@
 ##
 
 import unittest
-from edk2toollib.windows.capsule.inf_generator import InfGenerator
+import tempfile
+import os
+from edk2toollib.windows.capsule.inf_generator import InfGenerator, InfSection
+
+
+class InfSectionTest(unittest.TestCase):
+    def test_empty(self):
+        section = InfSection('TestSection')
+        self.assertEqual(str(section), "[TestSection]")
+
+    def test_single(self):
+        section = InfSection("Test")
+        section.Items.append("Item")
+        self.assertEqual(str(section), "[Test]\nItem")
+
+    def test_multiple(self):
+        section = InfSection("Test")
+        section.Items.append("Item1")
+        section.Items.append("Item2")
+        self.assertEqual(str(section), "[Test]\nItem1\nItem2")
 
 
 class InfGeneratorTest(unittest.TestCase):
@@ -35,6 +54,19 @@ class InfGeneratorTest(unittest.TestCase):
         # set manufacturer
         o.Manufacturer = "manufacturer"
         self.assertEqual("manufacturer", o.Manufacturer)
+
+    def test_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            inffile_path = os.path.join(tmpdir, "InfFile.inf")
+            infgen = InfGenerator('TestName', 'TestProvider', InfGeneratorTest.VALID_GUID_STRING, "x64", "Test Description", "1.2.3.4", "0x01020304")
+            infgen.MakeInf(inffile_path, "TestFirmwareRom.bin", False)
+
+            with open(inffile_path, "r") as inffile:
+                file_contents = inffile.read()
+                # Remove all whitespace, just in case.
+                file_contents = file_contents.replace("\n", "").replace("\t", "").replace(" ", "")
+                test_contents = TEST_FILE_CONTENTS.replace("\n", "").replace("\t", "").replace(" ", "")
+                self.assertEqual(test_contents, file_contents)
 
     def test_invalid_name_symbol(self):
 
@@ -76,3 +108,59 @@ class InfGeneratorTest(unittest.TestCase):
     def test_invalid_guid_format(self):
         with self.assertRaises(ValueError):
             InfGenerator("test_name", "provider", "NOT A VALID GUID", "x64", "description", "aa.bb", "0x1000000")
+
+
+TEST_FILE_CONTENTS = ''';
+; TestName.inf
+; 1.2.3.4
+; Copyright (C) 2019 Microsoft Corporation.  All Rights Reserved.
+;
+[Version]
+Signature="$WINDOWS NT$"
+Class=Firmware
+ClassGuid={f2e7dd72-6468-4e36-b6f1-6488f42c1b52}
+Provider=%Provider%
+DriverVer=06/10/2021,1.2.3.4
+PnpLockdown=1
+CatalogFile=TestName.cat
+
+[Manufacturer]
+%MfgName% = Firmware,NTamd64
+
+[Firmware.NTamd64]
+%FirmwareDesc% = Firmware_Install,UEFI\\RES_{3cad7a0c-d35b-4b75-96b1-03a9fb07b7fc}
+
+[Firmware_Install.NT]
+CopyFiles = Firmware_CopyFiles
+
+[Firmware_CopyFiles]
+TestFirmwareRom.bin
+
+[Firmware_Install.NT.Hw]
+AddReg = Firmware_AddReg
+
+[Firmware_AddReg]
+HKR,,FirmwareId,,{3cad7a0c-d35b-4b75-96b1-03a9fb07b7fc}
+HKR,,FirmwareVersion,%REG_DWORD%,0x1020304
+HKR,,FirmwareFilename,,TestFirmwareRom.bin
+
+[SourceDisksNames]
+1 = %DiskName%
+
+[SourceDisksFiles]
+TestFirmwareRom.bin = 1
+
+[DestinationDirs]
+DefaultDestDir = %DIRID_WINDOWS%,Firmware ; %SystemRoot%\Firmware
+
+[Strings]
+; localizable
+Provider     = "TestProvider"
+MfgName      = "TestProvider"
+FirmwareDesc = "Test Description"
+DiskName     = "Firmware Update"
+
+; non-localizable
+DIRID_WINDOWS = 10
+REG_DWORD     = 0x00010001
+'''


### PR DESCRIPTION
Add the ability to set the IntegrityFilename and populate the data in the produced INF file.

Also refactored the way some of the INF sections are produced to make it easier to dynamically
add entries to these sections.