### PR TITLE
Fix `SECTION GUIDED` parsing

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/fdf_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/fdf_parser.py
@@ -143,7 +143,6 @@ class FdfParser(HashFileParser):
                             if sline.upper().startswith("SECTION GUIDED"):  # get the guided section
                                 section_def = sline[14:].strip().split("=", 1)
                                 sectionType = section_def[0].strip()  # UI in this example
-                                sectionValue = section_def[1].strip()
                                 if sectionType not in self.FVs[section]["Files"][currentName]:
                                     self.FVs[section]["Files"][currentName][sectionType] = {}
                                 # TODO support guided sections

--- a/edk2toollib/uefi/edk2/parsers/fdf_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/fdf_parser.py
@@ -139,10 +139,10 @@ class FdfParser(HashFileParser):
 
                         while self._BracketCount > 0:  # go until we get our bracket back
                             sline = self.GetNextLine().strip("}{ ")
-                            # SECTION GUIDED EE4E5898-3914-4259-9D6E-DC7BD79403CF PROCESSING_REQUIRED = TRUE
+                            # SECTION GUIDED EE4E5898-3914-4259-9D6E-DC7BD79403CF
                             if sline.upper().startswith("SECTION GUIDED"):  # get the guided section
                                 section_def = sline[14:].strip().split("=", 1)
-                                sectionType = section_def[0].strip()  # UI in this example
+                                sectionType = section_def[0].strip()  # EE4E5898-3914-4259-9D6E-DC7BD79403CF in this example
                                 if sectionType not in self.FVs[section]["Files"][currentName]:
                                     self.FVs[section]["Files"][currentName][sectionType] = {}
                                 # TODO support guided sections

--- a/edk2toollib/uefi/edk2/parsers/fdf_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/fdf_parser.py
@@ -142,7 +142,8 @@ class FdfParser(HashFileParser):
                             # SECTION GUIDED EE4E5898-3914-4259-9D6E-DC7BD79403CF
                             if sline.upper().startswith("SECTION GUIDED"):  # get the guided section
                                 section_def = sline[14:].strip().split("=", 1)
-                                sectionType = section_def[0].strip()  # EE4E5898-3914-4259-9D6E-DC7BD79403CF in this example
+                                # EE4E5898-3914-4259-9D6E-DC7BD79403CF in this example
+                                sectionType = section_def[0].strip()
                                 if sectionType not in self.FVs[section]["Files"][currentName]:
                                     self.FVs[section]["Files"][currentName][sectionType] = {}
                                 # TODO support guided sections

--- a/edk2toollib/uefi/edk2/parsers/test/fdf_parser_test.py
+++ b/edk2toollib/uefi/edk2/parsers/test/fdf_parser_test.py
@@ -75,6 +75,7 @@ class TestBasicFdfParser(unittest.TestCase):
         self.assertEqual(parser.Dict['NUM_BLOCKS'], '0x410')
         self.assertEqual(parser.Dict['CONDITIONAL_VALUE'], '121')
 
+
 def test_section_guided():
     """Check that SECTION GUIDED can be added."""
     # Given
@@ -96,4 +97,5 @@ def test_section_guided():
         os.remove(fdf_path)
 
     # Then
-    assert "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" in parser.FVs["MAINFV"]["Files"]["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]
+    assert "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" in \
+        parser.FVs["MAINFV"]["Files"]["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]

--- a/edk2toollib/uefi/edk2/parsers/test/fdf_parser_test.py
+++ b/edk2toollib/uefi/edk2/parsers/test/fdf_parser_test.py
@@ -79,6 +79,7 @@ class TestBasicFdfParser(unittest.TestCase):
 def test_section_guided():
     """Check that SECTION GUIDED can be added."""
     # Given
+    # cSpell:ignore MAINFV
     SAMPLE_FDF_FILE = textwrap.dedent("""\
         [FV.MAINFV]
         FILE PEIM = aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa{

--- a/edk2toollib/uefi/edk2/parsers/test/fdf_parser_test.py
+++ b/edk2toollib/uefi/edk2/parsers/test/fdf_parser_test.py
@@ -9,6 +9,8 @@
 
 import unittest
 import os
+import textwrap
+import tempfile
 from edk2toollib.uefi.edk2.parsers.fdf_parser import FdfParser
 
 TEST_PATH = os.path.realpath(os.path.dirname(__file__))
@@ -72,3 +74,26 @@ class TestBasicFdfParser(unittest.TestCase):
         self.assertEqual(parser.Dict['INTERNAL_VALUE'], '104')
         self.assertEqual(parser.Dict['NUM_BLOCKS'], '0x410')
         self.assertEqual(parser.Dict['CONDITIONAL_VALUE'], '121')
+
+def test_section_guided():
+    """Check that SECTION GUIDED can be added."""
+    # Given
+    SAMPLE_FDF_FILE = textwrap.dedent("""\
+        [FV.MAINFV]
+        FILE PEIM = aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa{
+            SECTION GUIDED bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
+        }
+    """)
+    try:
+        with tempfile.NamedTemporaryFile(mode='w', encoding='utf-8', delete=False) as f:
+            f.write(SAMPLE_FDF_FILE)
+            fdf_path = f.name
+
+        # When
+        parser = FdfParser()
+        parser.ParseFile(fdf_path)
+    finally:
+        os.remove(fdf_path)
+
+    # Then
+    assert "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" in parser.FVs["MAINFV"]["Files"]["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]


### PR DESCRIPTION
`sectionValue` wasn't being used and it broke the parsing on sections that didn't have a `x = y` part of the section.