### PR TITLE
Add a new inf_generator2 module with support for generating multi-node capsules

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -90,6 +90,7 @@
         "iommu",
         "smoosh",
         "markdownlint",
-        "codecov"
+        "codecov",
+        "nonlocalizable"
     ]
 }

--- a/edk2toollib/windows/capsule/inf_generator2.py
+++ b/edk2toollib/windows/capsule/inf_generator2.py
@@ -1,0 +1,197 @@
+##
+# Module to generate inf files for capsule update. Supports targeting
+# multiple ESRT nodes with the same INF.
+#
+# Copyright (c) Microsoft Corporation
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+import textwrap
+
+
+class InfHeader(object):
+    def __init__(self, name, versionStr, date, arch, provider, mfgname, infstrings):
+        self.name = name
+        self.versionStr = versionStr
+        self.date = date
+        self.arch = arch
+        infstrings.addLocalizableString("Provider", provider)
+        infstrings.addLocalizableString("MfgName", mfgname)
+
+    def __str__(self):
+        return textwrap.dedent(f"""\
+            ;
+            ; {self.name}
+            ; {self.versionStr}
+            ; Copyright (C) Microsoft Corporation. All rights Reserved.
+            ;
+            [Version]
+            Signature="$WINDOWS NT$"
+            Class=Firmware
+            ClassGuid={{f2e7dd72-6468-4e36-b6f1-6488f42c1b52}}
+            Provider=%Provider%
+            DriverVer={self.date},{self.versionStr}
+            PnpLockdown=1
+            CatalogFile={self.name}.cat
+
+            [Manufacturer]
+            %MfgName% = Firmware,NT{self.arch}
+
+            """)
+
+
+class InfFirmware(object):
+    def __init__(self, tag, desc, esrtGuid, versionInt, firmwareFile, infStrings, infSourceFiles,
+                 rollback=False, integrityFile=None):
+        self.tag = tag
+        self.desc = desc
+        self.esrtGuid = esrtGuid
+        self.versionInt = int(versionInt, base=0)
+        self.firmwareFile = firmwareFile
+        infSourceFiles.addFile(firmwareFile)
+        self.rollback = rollback
+        self.integrityFile = integrityFile
+        if (self.integrityFile is not None):
+            infSourceFiles.addFile(integrityFile)
+        infStrings.addNonlocalizableString("REG_DWORD", "0x00010001")
+
+    def __str__(self):
+        # build rollback string, if required.
+        if (self.rollback):
+            rollbackStr = textwrap.dedent(f"""\
+                AddReg = {self.tag}_DowngradePolicy_AddReg
+
+                [{self.tag}_DowngradePolicy_AddReg]
+                HKLM,SYSTEM\\CurrentControlSet\\Control\\FirmwareResources\\{{{self.esrtGuid}}},Policy,%REG_DWORD%,1
+                """)
+        else:
+            rollbackStr = ""
+
+        # build integrity file string, if required.
+        if (self.integrityFile is not None):
+            integrityFile = f"{self.integrityFile}\n"
+            integrityFileReg = f"HKR,,FirmwareIntegrityFilename,,{self.integrityFile}\n"
+        else:
+            integrityFile = ""
+            integrityFileReg = ""
+
+        outstr = textwrap.dedent(f"""\
+            [{self.tag}_Install.NT]
+            CopyFiles = {self.tag}_CopyFiles
+            """)
+        outstr += rollbackStr
+        outstr += textwrap.dedent(f"""
+            [{self.tag}_CopyFiles]
+            {self.firmwareFile}
+            """)
+        outstr += integrityFile
+        outstr += textwrap.dedent(f"""
+            [{self.tag}_Install.NT.Hw]
+            AddReg = {self.tag}_AddReg
+
+            [{self.tag}_AddReg]
+            HKR,,FirmwareId,,{{{self.esrtGuid}}}
+            HKR,,FirmwareVersion,%REG_DWORD%,0x{self.versionInt:X}
+            HKR,,FirmwareFilename,,{self.firmwareFile}
+            """)
+        outstr += integrityFileReg + "\n"
+        return outstr
+
+
+class InfFirmwareSections(object):
+    def __init__(self, arch, infstrings):
+        self.arch = arch
+        self.sections = {}
+        self.infstrings = infstrings
+
+    def AddSection(self, infFirmware):
+        self.sections[infFirmware.tag] = infFirmware
+        self.infstrings.addLocalizableString(f"{infFirmware.tag}Desc", infFirmware.desc)
+
+    def __str__(self):
+        firmwareStr = f"[Firmware.NT{self.arch}]\n"
+        for (infFirmware) in self.sections.values():
+            firmwareStr += f"%{infFirmware.tag}Desc% = {infFirmware.tag}_Install,UEFI\\RES_{{{infFirmware.esrtGuid}}}\n"
+        firmwareStr += "\n"
+        for (infFirmware) in self.sections.values():
+            firmwareStr += str(infFirmware)
+
+        return firmwareStr
+
+
+class InfSourceFiles(object):
+    def __init__(self, diskname, infstrings):
+        self.files = []
+        infstrings.addLocalizableString('DiskName', diskname)
+        infstrings.addNonlocalizableString('DIRID_WINDOWS', "10")
+
+    def addFile(self, filename):
+        if (filename not in self.files):
+            self.files.append(filename)
+
+    def __str__(self):
+        files = ''.join("{0} = 1\n".format(file) for file in self.files)
+        outstr = textwrap.dedent("""\
+            [SourceDisksNames]
+            1 = %DiskName%
+
+            [SourceDisksFiles]
+            """)
+        outstr += files
+        outstr += textwrap.dedent("""
+            [DestinationDirs]
+            DefaultDestDir = %DIRID_WINDOWS%,Firmware ; %SystemRoot%\\Firmware
+
+            """)
+        return outstr
+
+
+class InfStrings(object):
+    def __init__(self):
+        self.localizableStrings = {}
+        self.nonlocalizableStrings = {}
+
+    def addLocalizableString(self, key, value):
+        self.localizableStrings[key] = value
+
+    def addNonlocalizableString(self, key, value):
+        self.nonlocalizableStrings[key] = value
+
+    def __str__(self):
+        localizedStrings = ""
+        longestKey = max(len(key) for key in self.localizableStrings.keys())
+        for (key, value) in self.localizableStrings.items():
+            localizedStrings += '{0:{width}} = "{1}"\n'.format(key, value, width=longestKey)
+
+        nonlocalizedStrings = ""
+        longestKey = max(len(key) for key in self.nonlocalizableStrings.keys())
+        for (key, value) in self.nonlocalizableStrings.items():
+            nonlocalizedStrings += "{0:{width}} = {1}\n".format(key, value, width=longestKey)
+
+        outstr = textwrap.dedent("""\
+            [Strings]
+            ; localizable
+            """)
+        outstr += localizedStrings
+        outstr += textwrap.dedent("""
+            ; non-localizable
+            """)
+        outstr += nonlocalizedStrings
+        return outstr
+
+
+class InfFile(object):
+    def __init__(self, name, versionStr, date, provider, mfgname, arch='amd64', diskname="Firmware Update"):
+        self.infStrings = InfStrings()
+        self.infSourceFiles = InfSourceFiles(diskname, self.infStrings)
+        self.infHeader = InfHeader(name, versionStr, date, arch, provider, mfgname, self.infStrings)
+        self.infFirmwareSections = InfFirmwareSections(arch, self.infStrings)
+
+    def addFirmware(self, tag, desc, esrtGuid, versionInt, firmwareFile, rollback=False, integrityFile=None):
+        firmwareSection = InfFirmware(tag, desc, esrtGuid, versionInt, firmwareFile,
+                                      self.infStrings, self.infSourceFiles, rollback, integrityFile)
+        self.infFirmwareSections.AddSection(firmwareSection)
+
+    def __str__(self):
+        return str(self.infHeader) + str(self.infFirmwareSections) + str(self.infSourceFiles) + str(self.infStrings)

--- a/edk2toollib/windows/capsule/inf_generator2.py
+++ b/edk2toollib/windows/capsule/inf_generator2.py
@@ -38,8 +38,8 @@ class InfHeader(object):
         self.VersionStr = VersionStr
         self.Date = CreationDate
         self.Arch = Arch
-        InfStrings.addLocalizableString("Provider", Provider)
-        InfStrings.addLocalizableString("MfgName", Manufacturer)
+        InfStrings.AddLocalizableString("Provider", Provider)
+        InfStrings.AddLocalizableString("MfgName", Manufacturer)
 
     @property
     def Name(self):
@@ -128,12 +128,12 @@ class InfFirmware(object):
         self.EsrtGuid = EsrtGuid
         self.VersionInt = VersionInt
         self.FirmwareFile = FirmwareFile
-        InfSourceFiles.addFile(FirmwareFile)
+        InfSourceFiles.AddFile(FirmwareFile)
         self.Rollback = Rollback
         self.IntegrityFile = IntegrityFile
         if (self.IntegrityFile is not None):
-            InfSourceFiles.addFile(IntegrityFile)
-        InfStrings.addNonLocalizableString("REG_DWORD", "0x00010001")
+            InfSourceFiles.AddFile(IntegrityFile)
+        InfStrings.AddNonLocalizableString("REG_DWORD", "0x00010001")
 
     @property
     def Tag(self):
@@ -236,7 +236,7 @@ class InfFirmwareSections(object):
         InfFirmware - an InfFirmware object representing a firmware section to be added to this collection of sections.
         '''
         self.Sections[InfFirmware.Tag] = InfFirmware
-        self.InfStrings.addLocalizableString(f"{InfFirmware.Tag}Desc", InfFirmware.Description)
+        self.InfStrings.AddLocalizableString(f"{InfFirmware.Tag}Desc", InfFirmware.Description)
 
     def __str__(self) -> str:
         '''
@@ -260,10 +260,10 @@ class InfSourceFiles(object):
         InfStrings  - An InfStrings object representing the "Strings" section of this INF file.
         '''
         self.Files = []
-        InfStrings.addLocalizableString('DiskName', DiskName)
-        InfStrings.addNonLocalizableString('DIRID_WINDOWS', "10")
+        InfStrings.AddLocalizableString('DiskName', DiskName)
+        InfStrings.AddNonLocalizableString('DIRID_WINDOWS', "10")
 
-    def addFile(self, Filename: str) -> None:
+    def AddFile(self, Filename: str) -> None:
         '''Adds a new file to this InfSourceFiles object
 
         Filename - Filename (basename only) of the file to be added. (e.g. "Firmware1234.bin")
@@ -302,7 +302,7 @@ class InfStrings(object):
         self.LocalizableStrings = {}
         self.NonLocalizableStrings = {}
 
-    def addLocalizableString(self, Key: str, Value: str) -> None:
+    def AddLocalizableString(self, Key: str, Value: str) -> None:
         '''Add a Localizable string to the collection of strings for this INF.
 
         Key     - the name of this string as it is used in the INF (e.g. "MfgName"). Note: the INF will typically
@@ -316,7 +316,7 @@ class InfStrings(object):
             raise ValueError("Key has invalid chars.")
         self.LocalizableStrings[Key] = Value
 
-    def addNonLocalizableString(self, Key: str, Value: str) -> None:
+    def AddNonLocalizableString(self, Key: str, Value: str) -> None:
         '''Add a Non-Localizable string to the collection of strings for this INF.
 
         Key     - the name of this string as it is used in the INF (e.g. "REG_DWORD"). Note: the INF will typically
@@ -375,7 +375,7 @@ class InfFile(object):
         self.InfHeader = InfHeader(Name, VersionStr, CreationDate, Arch, Provider, ManufacturerName, self.InfStrings)
         self.InfFirmwareSections = InfFirmwareSections(Arch, self.InfStrings)
 
-    def addFirmware(self, Tag: str, Description: str, EsrtGuid: str, VersionInt: str, FirmwareFile: str,
+    def AddFirmware(self, Tag: str, Description: str, EsrtGuid: str, VersionInt: str, FirmwareFile: str,
                     Rollback: bool = False, IntegrityFile: str = None) -> None:
         '''Adds a firmware target to the INF.
 

--- a/edk2toollib/windows/capsule/inf_generator2.py
+++ b/edk2toollib/windows/capsule/inf_generator2.py
@@ -11,7 +11,8 @@ import textwrap
 
 
 class InfHeader(object):
-    def __init__(self, Name, VersionStr, CreationDate, Arch, Provider, Manufacturer, InfStrings):
+    def __init__(self, Name: str, VersionStr: str, CreationDate: str, Arch: str, Provider: str, Manufacturer: str,
+                 InfStrings: 'InfStrings') -> None:
         '''Instantiate an INF header object.
         This object represents the INF header at the start of the INF file.
 
@@ -30,7 +31,7 @@ class InfHeader(object):
         InfStrings.addLocalizableString("Provider", Provider)
         InfStrings.addLocalizableString("MfgName", Manufacturer)
 
-    def __str__(self):
+    def __str__(self) -> str:
         '''Return the string representation of this InfHeader object'''
         return textwrap.dedent(f"""\
             ;
@@ -54,8 +55,9 @@ class InfHeader(object):
 
 
 class InfFirmware(object):
-    def __init__(self, Tag, Description, EsrtGuid, VersionInt, FirmwareFile, InfStrings, InfSourceFiles,
-                 Rollback=False, IntegrityFile=None):
+    def __init__(self, Tag: str, Description: str, EsrtGuid: str, VersionInt: str, FirmwareFile: str,
+                 InfStrings: 'InfStrings', InfSourceFiles: 'InfSourceFiles', Rollback=False,
+                 IntegrityFile=None) -> None:
         '''Instantiate an INF firmware object.
         This object represents individual firmware sections within the INF.
 
@@ -82,7 +84,7 @@ class InfFirmware(object):
             InfSourceFiles.addFile(IntegrityFile)
         InfStrings.addNonLocalizableString("REG_DWORD", "0x00010001")
 
-    def __str__(self):
+    def __str__(self) -> str:
         '''Return the string representation of this InfFirmware object'''
         # build rollback string, if required.
         if (self.Rollback):
@@ -127,7 +129,7 @@ class InfFirmware(object):
 
 
 class InfFirmwareSections(object):
-    def __init__(self, Arch, InfStrings):
+    def __init__(self, Arch: str, InfStrings: 'InfStrings') -> None:
         '''Instantiate an INF firmware sections object.
         This object represents a collection of firmware sections and associated common metadata.
 
@@ -138,7 +140,7 @@ class InfFirmwareSections(object):
         self.Sections = {}
         self.InfStrings = InfStrings
 
-    def AddSection(self, InfFirmware):
+    def AddSection(self, InfFirmware: InfFirmware) -> None:
         '''Adds an InfFirmware section object to the set of firmware sections in this InfFirmwareSections object.
 
         InfFirmware - an InfFirmware object representing a firmware section to be added to this collection of sections.
@@ -146,7 +148,7 @@ class InfFirmwareSections(object):
         self.Sections[InfFirmware.Tag] = InfFirmware
         self.InfStrings.addLocalizableString(f"{InfFirmware.Tag}Desc", InfFirmware.Description)
 
-    def __str__(self):
+    def __str__(self) -> str:
         '''
         Return the string representation of this InfFirmwareSections object (including any InfFirmware objects in it)
         '''
@@ -160,7 +162,7 @@ class InfFirmwareSections(object):
 
 
 class InfSourceFiles(object):
-    def __init__(self, DiskName, InfStrings):
+    def __init__(self, DiskName: str, InfStrings: 'InfStrings') -> None:
         '''Instantiate an INF source files object.
         This object represents the collection of source files that are referenced by other sections of the INF.
 
@@ -171,7 +173,7 @@ class InfSourceFiles(object):
         InfStrings.addLocalizableString('DiskName', DiskName)
         InfStrings.addNonLocalizableString('DIRID_WINDOWS', "10")
 
-    def addFile(self, Filename):
+    def addFile(self, Filename: str) -> None:
         '''Adds a new file to this InfSourceFiles object
 
         Filename - Filename (basename only) of the file to be added. (e.g. "Firmware1234.bin")
@@ -179,7 +181,7 @@ class InfSourceFiles(object):
         if (Filename not in self.Files):
             self.Files.append(Filename)
 
-    def __str__(self):
+    def __str__(self) -> str:
         '''Return the string representation of this InfSourceFIles object'''
         Files = ''.join("{0} = 1\n".format(file) for file in self.Files)
         outstr = textwrap.dedent("""\
@@ -198,7 +200,7 @@ class InfSourceFiles(object):
 
 
 class InfStrings(object):
-    def __init__(self):
+    def __init__(self) -> None:
         '''Instantiate an INF strings object.
         This object represents the collection of strings (localizable or non-localizable) that are referenced by other
         sections of the INF.
@@ -206,7 +208,7 @@ class InfStrings(object):
         self.LocalizableStrings = {}
         self.NonLocalizableStrings = {}
 
-    def addLocalizableString(self, Key, Value):
+    def addLocalizableString(self, Key: str, Value: str) -> None:
         '''Add a Localizable string to the collection of strings for this INF.
 
         Key     - the name of this string as it is used in the INF (e.g. "MfgName"). Note: the INF will typically
@@ -216,7 +218,7 @@ class InfStrings(object):
         '''
         self.LocalizableStrings[Key] = Value
 
-    def addNonLocalizableString(self, Key, Value):
+    def addNonLocalizableString(self, Key: str, Value: str) -> None:
         '''Add a Non-Localizable string to the collection of strings for this INF.
 
         Key     - the name of this string as it is used in the INF (e.g. "REG_DWORD"). Note: the INF will typically
@@ -226,7 +228,7 @@ class InfStrings(object):
         '''
         self.NonLocalizableStrings[Key] = Value
 
-    def __str__(self):
+    def __str__(self) -> str:
         '''Return the string representation of this InfStrings object'''
         LocalizedStrings = ""
         LongestKey = max(len(Key) for Key in self.LocalizableStrings.keys())
@@ -251,8 +253,8 @@ class InfStrings(object):
 
 
 class InfFile(object):
-    def __init__(self, Name, VersionStr, CreationDate, Provider, ManufacturerName, Arch='amd64',
-                 DiskName="Firmware Update"):
+    def __init__(self, Name: str, VersionStr: str, CreationDate: str, Provider: str, ManufacturerName: str,
+                 Arch: str = 'amd64', DiskName: str = "Firmware Update") -> None:
         '''Instantiate an INF file object.
         This object represents the entire INF file.
 
@@ -271,7 +273,8 @@ class InfFile(object):
         self.InfHeader = InfHeader(Name, VersionStr, CreationDate, Arch, Provider, ManufacturerName, self.InfStrings)
         self.InfFirmwareSections = InfFirmwareSections(Arch, self.InfStrings)
 
-    def addFirmware(self, Tag, Description, EsrtGuid, VersionInt, FirmwareFile, Rollback=False, IntegrityFile=None):
+    def addFirmware(self, Tag: str, Description: str, EsrtGuid: str, VersionInt: str, FirmwareFile: str,
+                    Rollback: bool = False, IntegrityFile: str = None) -> None:
         '''Adds a firmware target to the INF.
 
         Tag             - A string that uniquely identifies this firmware (e.g. "Firmware0")
@@ -287,7 +290,7 @@ class InfFile(object):
                                       self.InfStrings, self.InfSourceFiles, Rollback, IntegrityFile)
         self.InfFirmwareSections.AddSection(firmwareSection)
 
-    def __str__(self):
+    def __str__(self) -> str:
         '''
         Returns the string representation of this InfFile object. The resulting string is suitable for writing to an
         INF file for inclusion in a capsule package.'''

--- a/edk2toollib/windows/capsule/inf_generator2.py
+++ b/edk2toollib/windows/capsule/inf_generator2.py
@@ -24,7 +24,7 @@ class InfHeader(object):
             ;
             ; {self.name}
             ; {self.versionStr}
-            ; Copyright (C) Microsoft Corporation. All rights Reserved.
+            ; Copyright (C) Microsoft Corporation. All Rights Reserved.
             ;
             [Version]
             Signature="$WINDOWS NT$"

--- a/edk2toollib/windows/capsule/inf_generator2.py
+++ b/edk2toollib/windows/capsule/inf_generator2.py
@@ -107,8 +107,8 @@ class InfHeader(object):
 
 class InfFirmware(object):
     def __init__(self, Tag: str, Description: str, EsrtGuid: str, VersionInt: str, FirmwareFile: str,
-                 InfStrings: 'InfStrings', InfSourceFiles: 'InfSourceFiles', Rollback=False,
-                 IntegrityFile=None) -> None:
+                 InfStrings: 'InfStrings', InfSourceFiles: 'InfSourceFiles', Rollback: bool = False,
+                 IntegrityFile: str = None) -> None:
         '''Instantiate an INF firmware object.
         This object represents individual firmware sections within the INF.
 

--- a/edk2toollib/windows/capsule/inf_generator2.py
+++ b/edk2toollib/windows/capsule/inf_generator2.py
@@ -11,6 +11,7 @@ import textwrap
 import re
 import uuid
 from datetime import datetime
+from typing import Optional
 
 SUPPORTED_ARCH = {'amd64': 'amd64',
                   'x64': 'amd64',
@@ -107,8 +108,8 @@ class InfHeader(object):
 
 class InfFirmware(object):
     def __init__(self, Tag: str, Description: str, EsrtGuid: str, VersionInt: str, FirmwareFile: str,
-                 InfStrings: 'InfStrings', InfSourceFiles: 'InfSourceFiles', Rollback: bool = False,
-                 IntegrityFile: str = None) -> None:
+                 InfStrings: 'InfStrings', InfSourceFiles: 'InfSourceFiles', Rollback: Optional[bool] = False,
+                 IntegrityFile: Optional[str] = None) -> None:
         '''Instantiate an INF firmware object.
         This object represents individual firmware sections within the INF.
 
@@ -118,7 +119,7 @@ class InfFirmware(object):
         VersionInt      - Version as an integer in string format (e.g. "1234" or "0x04158000")
         FirmwareFile    - Filename (basename only) of the firmware payload file (e.g. "Firmware1234.bin")
         InfStrings      - An InfStrings object representing the "Strings" section of this INF file.
-        InfSourceFiles  - An InfSourceFIles object representing the "SourceDisks*" sections of this INF file.
+        InfSourceFiles  - An InfSourceFiles object representing the "SourceDisks*" sections of this INF file.
         Rollback        - Specifies whether this firmware should be enabled for rollback (optional, default: False)
         IntegrityFile   - Filename (basename only) of the integrity file associated with this firmware (e.g.
                           "integrity123.bin"). Optional - if not specified, no integrity file will be included.
@@ -356,7 +357,7 @@ class InfStrings(object):
 
 class InfFile(object):
     def __init__(self, Name: str, VersionStr: str, CreationDate: str, Provider: str, ManufacturerName: str,
-                 Arch: str = 'amd64', DiskName: str = "Firmware Update") -> None:
+                 Arch: Optional[str] = 'amd64', DiskName: Optional[str] = "Firmware Update") -> None:
         '''Instantiate an INF file object.
         This object represents the entire INF file.
 
@@ -376,7 +377,7 @@ class InfFile(object):
         self.InfFirmwareSections = InfFirmwareSections(Arch, self.InfStrings)
 
     def AddFirmware(self, Tag: str, Description: str, EsrtGuid: str, VersionInt: str, FirmwareFile: str,
-                    Rollback: bool = False, IntegrityFile: str = None) -> None:
+                    Rollback: Optional[bool] = False, IntegrityFile: Optional[str] = None) -> None:
         '''Adds a firmware target to the INF.
 
         Tag             - A string that uniquely identifies this firmware (e.g. "Firmware0")

--- a/edk2toollib/windows/capsule/inf_generator2_test.py
+++ b/edk2toollib/windows/capsule/inf_generator2_test.py
@@ -1,0 +1,646 @@
+## @file
+# UnitTest for inf_generator.py
+#
+# Copyright (c) Microsoft Corporation
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+import unittest
+import textwrap
+from edk2toollib.windows.capsule.inf_generator2 import InfHeader, InfStrings, InfSourceFiles, InfFirmware
+from edk2toollib.windows.capsule.inf_generator2 import InfFirmwareSections, InfFile
+
+
+class InfHeaderTest(unittest.TestCase):
+    def test_header(self):
+        infStrings = InfStrings()
+        infHeader = InfHeader("InfTest", "1.0.0.1", "01/01/2021", "amd64", "testprovider", "testmfr", infStrings)
+
+        expectedStr = textwrap.dedent("""\
+            ;
+            ; InfTest
+            ; 1.0.0.1
+            ; Copyright (C) Microsoft Corporation. All rights Reserved.
+            ;
+            [Version]
+            Signature="$WINDOWS NT$"
+            Class=Firmware
+            ClassGuid={f2e7dd72-6468-4e36-b6f1-6488f42c1b52}
+            Provider=%Provider%
+            DriverVer=01/01/2021,1.0.0.1
+            PnpLockdown=1
+            CatalogFile=InfTest.cat
+
+            [Manufacturer]
+            %MfgName% = Firmware,NTamd64
+
+            """)
+        self.assertEqual(expectedStr, str(infHeader))
+        self.assertIn("Provider", infStrings.localizableStrings)
+        self.assertEqual("testprovider", infStrings.localizableStrings['Provider'])
+        self.assertIn("MfgName", infStrings.localizableStrings)
+        self.assertEqual("testmfr", infStrings.localizableStrings['MfgName'])
+
+
+class InfFirmwareTest(unittest.TestCase):
+    def test_firmware(self):
+        infStrings = InfStrings()
+        infSourceFiles = InfSourceFiles("diskname", infStrings)
+
+        infFirmware = InfFirmware(
+            "tag",
+            "desc",
+            "34e094e9-4079-44cd-9450-3f2cb7824c97",
+            "0x01000001",
+            "test.bin",
+            infStrings,
+            infSourceFiles)
+
+        expectedStr = textwrap.dedent("""\
+            [tag_Install.NT]
+            CopyFiles = tag_CopyFiles
+
+            [tag_CopyFiles]
+            test.bin
+
+            [tag_Install.NT.Hw]
+            AddReg = tag_AddReg
+
+            [tag_AddReg]
+            HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
+            HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
+            HKR,,FirmwareFilename,,test.bin
+
+            """)
+
+        self.assertEqual(expectedStr, str(infFirmware))
+        self.assertEqual(infFirmware.desc, "desc")
+        self.assertIn("REG_DWORD", infStrings.nonlocalizableStrings)
+        self.assertEqual("0x00010001", infStrings.nonlocalizableStrings['REG_DWORD'])
+        self.assertIn("test.bin", infSourceFiles.files)
+
+    def test_rollback_firmware(self):
+        infStrings = InfStrings()
+        infSourceFiles = InfSourceFiles("diskname", infStrings)
+
+        infFirmware = InfFirmware(
+            "tag",
+            "desc",
+            "34e094e9-4079-44cd-9450-3f2cb7824c97",
+            "0x01000001",
+            "test.bin",
+            infStrings,
+            infSourceFiles,
+            rollback=True)
+
+        expectedStr = textwrap.dedent("""\
+            [tag_Install.NT]
+            CopyFiles = tag_CopyFiles
+            AddReg = tag_DowngradePolicy_AddReg
+
+            [tag_DowngradePolicy_AddReg]
+            HKLM,SYSTEM\\CurrentControlSet\\Control\\FirmwareResources\\{34e094e9-4079-44cd-9450-3f2cb7824c97},Policy,%REG_DWORD%,1
+
+            [tag_CopyFiles]
+            test.bin
+
+            [tag_Install.NT.Hw]
+            AddReg = tag_AddReg
+
+            [tag_AddReg]
+            HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
+            HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
+            HKR,,FirmwareFilename,,test.bin
+
+            """)
+
+        self.assertEqual(expectedStr, str(infFirmware))
+        self.assertEqual(infFirmware.desc, "desc")
+        self.assertIn("REG_DWORD", infStrings.nonlocalizableStrings)
+        self.assertEqual("0x00010001", infStrings.nonlocalizableStrings['REG_DWORD'])
+        self.assertIn("test.bin", infSourceFiles.files)
+
+    def test_rollback_firmware_integrity(self):
+        infStrings = InfStrings()
+        infSourceFiles = InfSourceFiles("diskname", infStrings)
+
+        infFirmware = InfFirmware(
+            "tag",
+            "desc",
+            "34e094e9-4079-44cd-9450-3f2cb7824c97",
+            "0x01000001",
+            "test.bin",
+            infStrings,
+            infSourceFiles,
+            rollback=True,
+            integrityFile="test2.bin")
+
+        expectedStr = textwrap.dedent("""\
+            [tag_Install.NT]
+            CopyFiles = tag_CopyFiles
+            AddReg = tag_DowngradePolicy_AddReg
+
+            [tag_DowngradePolicy_AddReg]
+            HKLM,SYSTEM\\CurrentControlSet\\Control\\FirmwareResources\\{34e094e9-4079-44cd-9450-3f2cb7824c97},Policy,%REG_DWORD%,1
+
+            [tag_CopyFiles]
+            test.bin
+            test2.bin
+
+            [tag_Install.NT.Hw]
+            AddReg = tag_AddReg
+
+            [tag_AddReg]
+            HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
+            HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
+            HKR,,FirmwareFilename,,test.bin
+            HKR,,FirmwareIntegrityFilename,,test2.bin
+
+            """)
+
+        self.assertEqual(expectedStr, str(infFirmware))
+        self.assertEqual(infFirmware.desc, "desc")
+        self.assertIn("REG_DWORD", infStrings.nonlocalizableStrings)
+        self.assertEqual("0x00010001", infStrings.nonlocalizableStrings['REG_DWORD'])
+        self.assertIn("test.bin", infSourceFiles.files)
+        self.assertIn("test2.bin", infSourceFiles.files)
+
+
+class InfFirmwareSectionsTest(unittest.TestCase):
+    def test_one_section(self):
+        infStrings = InfStrings()
+        infSourceFiles = InfSourceFiles("diskname", infStrings)
+
+        infFirmware = InfFirmware(
+            "tag",
+            "desc",
+            "34e094e9-4079-44cd-9450-3f2cb7824c97",
+            "0x01000001",
+            "test.bin",
+            infStrings,
+            infSourceFiles)
+
+        infSections = InfFirmwareSections('amd64', infStrings)
+        infSections.AddSection(infFirmware)
+
+        expectedStr = textwrap.dedent("""\
+            [Firmware.NTamd64]
+            %tagDesc% = tag_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
+
+            [tag_Install.NT]
+            CopyFiles = tag_CopyFiles
+
+            [tag_CopyFiles]
+            test.bin
+
+            [tag_Install.NT.Hw]
+            AddReg = tag_AddReg
+
+            [tag_AddReg]
+            HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
+            HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
+            HKR,,FirmwareFilename,,test.bin
+
+            """)
+
+        self.assertEqual(expectedStr, str(infSections))
+        self.assertIn("tagDesc", infStrings.localizableStrings)
+        self.assertEqual("desc", infStrings.localizableStrings['tagDesc'])
+        self.assertIn("test.bin", infSourceFiles.files)
+
+        self.assertIn("REG_DWORD", infStrings.nonlocalizableStrings)
+        self.assertEqual("0x00010001", infStrings.nonlocalizableStrings['REG_DWORD'])
+
+    def test_two_sections(self):
+        infStrings = InfStrings()
+        infSourceFiles = InfSourceFiles("diskname", infStrings)
+
+        infFirmware1 = InfFirmware(
+            "tag1",
+            "desc1",
+            "34e094e9-4079-44cd-9450-3f2cb7824c97",
+            "0x01000001",
+            "test1.bin",
+            infStrings,
+            infSourceFiles)
+
+        infFirmware2 = InfFirmware(
+            "tag2",
+            "desc2",
+            "bec9124f-9934-4ec0-a6ed-b8bc1c91d276",
+            "0x01000002",
+            "test2.bin",
+            infStrings,
+            infSourceFiles)
+
+        infSections = InfFirmwareSections('amd64', infStrings)
+        infSections.AddSection(infFirmware1)
+        infSections.AddSection(infFirmware2)
+
+        expectedStr = textwrap.dedent("""\
+            [Firmware.NTamd64]
+            %tag1Desc% = tag1_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
+            %tag2Desc% = tag2_Install,UEFI\\RES_{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
+
+            [tag1_Install.NT]
+            CopyFiles = tag1_CopyFiles
+
+            [tag1_CopyFiles]
+            test1.bin
+
+            [tag1_Install.NT.Hw]
+            AddReg = tag1_AddReg
+
+            [tag1_AddReg]
+            HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
+            HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
+            HKR,,FirmwareFilename,,test1.bin
+
+            [tag2_Install.NT]
+            CopyFiles = tag2_CopyFiles
+
+            [tag2_CopyFiles]
+            test2.bin
+
+            [tag2_Install.NT.Hw]
+            AddReg = tag2_AddReg
+
+            [tag2_AddReg]
+            HKR,,FirmwareId,,{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
+            HKR,,FirmwareVersion,%REG_DWORD%,0x1000002
+            HKR,,FirmwareFilename,,test2.bin
+
+            """)
+
+        self.assertEqual(expectedStr, str(infSections))
+        self.assertIn("tag1Desc", infStrings.localizableStrings)
+        self.assertEqual("desc1", infStrings.localizableStrings['tag1Desc'])
+        self.assertIn("test1.bin", infSourceFiles.files)
+        self.assertIn("tag2Desc", infStrings.localizableStrings)
+        self.assertEqual("desc2", infStrings.localizableStrings['tag2Desc'])
+        self.assertIn("test2.bin", infSourceFiles.files)
+
+        self.assertIn("REG_DWORD", infStrings.nonlocalizableStrings)
+        self.assertEqual("0x00010001", infStrings.nonlocalizableStrings['REG_DWORD'])
+
+
+class InfSourceFilesTest(unittest.TestCase):
+    def test_source_files(self):
+        infStrings = InfStrings()
+        infSourceFiles = InfSourceFiles("diskname", infStrings)
+        infSourceFiles.addFile("test.bin")
+        infSourceFiles.addFile("test2.bin")
+        infSourceFiles.addFile("test3.bin")
+
+        expectedStr = textwrap.dedent("""\
+            [SourceDisksNames]
+            1 = %DiskName%
+
+            [SourceDisksFiles]
+            test.bin = 1
+            test2.bin = 1
+            test3.bin = 1
+
+            [DestinationDirs]
+            DefaultDestDir = %DIRID_WINDOWS%,Firmware ; %SystemRoot%\\Firmware
+
+            """)
+
+        self.assertEqual(expectedStr, str(infSourceFiles))
+        self.assertIn("DiskName", infStrings.localizableStrings)
+        self.assertEqual("diskname", infStrings.localizableStrings['DiskName'])
+        self.assertIn("DIRID_WINDOWS", infStrings.nonlocalizableStrings)
+        self.assertEqual("10", infStrings.nonlocalizableStrings['DIRID_WINDOWS'])
+
+
+class InfStringsTest(unittest.TestCase):
+    def test_inf_strings(self):
+        infStrings = InfStrings()
+        infStrings.addLocalizableString("DiskName", "Firmware Update")
+        infStrings.addLocalizableString("Provider", "Test Provider")
+        infStrings.addLocalizableString("Tag1Desc", "Test Firmware")
+
+        infStrings.addNonlocalizableString("DIRID_WINDOWS", "10")
+        infStrings.addNonlocalizableString("REG_DWORD", "0x00010001")
+
+        expectedStr = textwrap.dedent("""\
+            [Strings]
+            ; localizable
+            DiskName = "Firmware Update"
+            Provider = "Test Provider"
+            Tag1Desc = "Test Firmware"
+
+            ; non-localizable
+            DIRID_WINDOWS = 10
+            REG_DWORD     = 0x00010001
+            """)
+
+        self.assertEqual(expectedStr, str(infStrings))
+
+
+class InfFileTest(unittest.TestCase):
+    def test_inf_file(self):
+        infFile = InfFile("CapsuleName", "1.0.0.1", "01/01/2021", "Test Provider", "Test Manufacturer")
+
+        infFile.addFirmware(
+            "tag1",
+            "desc1",
+            "34e094e9-4079-44cd-9450-3f2cb7824c97",
+            "0x01000001",
+            "test1.bin")
+
+        infFile.addFirmware(
+            "tag2",
+            "desc2",
+            "bec9124f-9934-4ec0-a6ed-b8bc1c91d276",
+            "0x01000002",
+            "test2.bin")
+
+        expectedStr = textwrap.dedent("""\
+            ;
+            ; CapsuleName
+            ; 1.0.0.1
+            ; Copyright (C) Microsoft Corporation. All rights Reserved.
+            ;
+            [Version]
+            Signature="$WINDOWS NT$"
+            Class=Firmware
+            ClassGuid={f2e7dd72-6468-4e36-b6f1-6488f42c1b52}
+            Provider=%Provider%
+            DriverVer=01/01/2021,1.0.0.1
+            PnpLockdown=1
+            CatalogFile=CapsuleName.cat
+
+            [Manufacturer]
+            %MfgName% = Firmware,NTamd64
+
+            [Firmware.NTamd64]
+            %tag1Desc% = tag1_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
+            %tag2Desc% = tag2_Install,UEFI\\RES_{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
+
+            [tag1_Install.NT]
+            CopyFiles = tag1_CopyFiles
+
+            [tag1_CopyFiles]
+            test1.bin
+
+            [tag1_Install.NT.Hw]
+            AddReg = tag1_AddReg
+
+            [tag1_AddReg]
+            HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
+            HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
+            HKR,,FirmwareFilename,,test1.bin
+
+            [tag2_Install.NT]
+            CopyFiles = tag2_CopyFiles
+
+            [tag2_CopyFiles]
+            test2.bin
+
+            [tag2_Install.NT.Hw]
+            AddReg = tag2_AddReg
+
+            [tag2_AddReg]
+            HKR,,FirmwareId,,{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
+            HKR,,FirmwareVersion,%REG_DWORD%,0x1000002
+            HKR,,FirmwareFilename,,test2.bin
+
+            [SourceDisksNames]
+            1 = %DiskName%
+
+            [SourceDisksFiles]
+            test1.bin = 1
+            test2.bin = 1
+
+            [DestinationDirs]
+            DefaultDestDir = %DIRID_WINDOWS%,Firmware ; %SystemRoot%\\Firmware
+
+            [Strings]
+            ; localizable
+            DiskName = "Firmware Update"
+            Provider = "Test Provider"
+            MfgName  = "Test Manufacturer"
+            tag1Desc = "desc1"
+            tag2Desc = "desc2"
+
+            ; non-localizable
+            DIRID_WINDOWS = 10
+            REG_DWORD     = 0x00010001
+            """)
+
+        self.assertEqual(expectedStr, str(infFile))
+
+    def test_inf_file_rollback(self):
+        infFile = InfFile("CapsuleName", "1.0.0.1", "01/01/2021", "Test Provider", "Test Manufacturer")
+
+        infFile.addFirmware(
+            "tag1",
+            "desc1",
+            "34e094e9-4079-44cd-9450-3f2cb7824c97",
+            "0x01000001",
+            "test1.bin",
+            rollback=True)
+
+        infFile.addFirmware(
+            "tag2",
+            "desc2",
+            "bec9124f-9934-4ec0-a6ed-b8bc1c91d276",
+            "0x01000002",
+            "test2.bin",
+            rollback=True)
+
+        expectedStr = textwrap.dedent("""\
+            ;
+            ; CapsuleName
+            ; 1.0.0.1
+            ; Copyright (C) Microsoft Corporation. All rights Reserved.
+            ;
+            [Version]
+            Signature="$WINDOWS NT$"
+            Class=Firmware
+            ClassGuid={f2e7dd72-6468-4e36-b6f1-6488f42c1b52}
+            Provider=%Provider%
+            DriverVer=01/01/2021,1.0.0.1
+            PnpLockdown=1
+            CatalogFile=CapsuleName.cat
+
+            [Manufacturer]
+            %MfgName% = Firmware,NTamd64
+
+            [Firmware.NTamd64]
+            %tag1Desc% = tag1_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
+            %tag2Desc% = tag2_Install,UEFI\\RES_{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
+
+            [tag1_Install.NT]
+            CopyFiles = tag1_CopyFiles
+            AddReg = tag1_DowngradePolicy_AddReg
+
+            [tag1_DowngradePolicy_AddReg]
+            HKLM,SYSTEM\\CurrentControlSet\\Control\\FirmwareResources\\{34e094e9-4079-44cd-9450-3f2cb7824c97},Policy,%REG_DWORD%,1
+
+            [tag1_CopyFiles]
+            test1.bin
+
+            [tag1_Install.NT.Hw]
+            AddReg = tag1_AddReg
+
+            [tag1_AddReg]
+            HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
+            HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
+            HKR,,FirmwareFilename,,test1.bin
+
+            [tag2_Install.NT]
+            CopyFiles = tag2_CopyFiles
+            AddReg = tag2_DowngradePolicy_AddReg
+
+            [tag2_DowngradePolicy_AddReg]
+            HKLM,SYSTEM\\CurrentControlSet\\Control\\FirmwareResources\\{bec9124f-9934-4ec0-a6ed-b8bc1c91d276},Policy,%REG_DWORD%,1
+
+            [tag2_CopyFiles]
+            test2.bin
+
+            [tag2_Install.NT.Hw]
+            AddReg = tag2_AddReg
+
+            [tag2_AddReg]
+            HKR,,FirmwareId,,{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
+            HKR,,FirmwareVersion,%REG_DWORD%,0x1000002
+            HKR,,FirmwareFilename,,test2.bin
+
+            [SourceDisksNames]
+            1 = %DiskName%
+
+            [SourceDisksFiles]
+            test1.bin = 1
+            test2.bin = 1
+
+            [DestinationDirs]
+            DefaultDestDir = %DIRID_WINDOWS%,Firmware ; %SystemRoot%\\Firmware
+
+            [Strings]
+            ; localizable
+            DiskName = "Firmware Update"
+            Provider = "Test Provider"
+            MfgName  = "Test Manufacturer"
+            tag1Desc = "desc1"
+            tag2Desc = "desc2"
+
+            ; non-localizable
+            DIRID_WINDOWS = 10
+            REG_DWORD     = 0x00010001
+            """)
+
+        self.assertEqual(expectedStr, str(infFile))
+
+    def test_inf_file_rollback_integrity(self):
+        self.maxDiff = None
+        infFile = InfFile("CapsuleName", "1.0.0.1", "01/01/2021", "Test Provider", "Test Manufacturer")
+
+        infFile.addFirmware(
+            "tag1",
+            "desc1",
+            "34e094e9-4079-44cd-9450-3f2cb7824c97",
+            "0x01000001",
+            "test1.bin",
+            rollback=True,
+            integrityFile="integrity1.bin")
+
+        infFile.addFirmware(
+            "tag2",
+            "desc2",
+            "bec9124f-9934-4ec0-a6ed-b8bc1c91d276",
+            "0x01000002",
+            "test2.bin",
+            rollback=True,
+            integrityFile="integrity2.bin")
+
+        expectedStr = textwrap.dedent("""\
+            ;
+            ; CapsuleName
+            ; 1.0.0.1
+            ; Copyright (C) Microsoft Corporation. All rights Reserved.
+            ;
+            [Version]
+            Signature="$WINDOWS NT$"
+            Class=Firmware
+            ClassGuid={f2e7dd72-6468-4e36-b6f1-6488f42c1b52}
+            Provider=%Provider%
+            DriverVer=01/01/2021,1.0.0.1
+            PnpLockdown=1
+            CatalogFile=CapsuleName.cat
+
+            [Manufacturer]
+            %MfgName% = Firmware,NTamd64
+
+            [Firmware.NTamd64]
+            %tag1Desc% = tag1_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
+            %tag2Desc% = tag2_Install,UEFI\\RES_{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
+
+            [tag1_Install.NT]
+            CopyFiles = tag1_CopyFiles
+            AddReg = tag1_DowngradePolicy_AddReg
+
+            [tag1_DowngradePolicy_AddReg]
+            HKLM,SYSTEM\\CurrentControlSet\\Control\\FirmwareResources\\{34e094e9-4079-44cd-9450-3f2cb7824c97},Policy,%REG_DWORD%,1
+
+            [tag1_CopyFiles]
+            test1.bin
+            integrity1.bin
+
+            [tag1_Install.NT.Hw]
+            AddReg = tag1_AddReg
+
+            [tag1_AddReg]
+            HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
+            HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
+            HKR,,FirmwareFilename,,test1.bin
+            HKR,,FirmwareIntegrityFilename,,integrity1.bin
+
+            [tag2_Install.NT]
+            CopyFiles = tag2_CopyFiles
+            AddReg = tag2_DowngradePolicy_AddReg
+
+            [tag2_DowngradePolicy_AddReg]
+            HKLM,SYSTEM\\CurrentControlSet\\Control\\FirmwareResources\\{bec9124f-9934-4ec0-a6ed-b8bc1c91d276},Policy,%REG_DWORD%,1
+
+            [tag2_CopyFiles]
+            test2.bin
+            integrity2.bin
+
+            [tag2_Install.NT.Hw]
+            AddReg = tag2_AddReg
+
+            [tag2_AddReg]
+            HKR,,FirmwareId,,{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
+            HKR,,FirmwareVersion,%REG_DWORD%,0x1000002
+            HKR,,FirmwareFilename,,test2.bin
+            HKR,,FirmwareIntegrityFilename,,integrity2.bin
+
+            [SourceDisksNames]
+            1 = %DiskName%
+
+            [SourceDisksFiles]
+            test1.bin = 1
+            integrity1.bin = 1
+            test2.bin = 1
+            integrity2.bin = 1
+
+            [DestinationDirs]
+            DefaultDestDir = %DIRID_WINDOWS%,Firmware ; %SystemRoot%\\Firmware
+
+            [Strings]
+            ; localizable
+            DiskName = "Firmware Update"
+            Provider = "Test Provider"
+            MfgName  = "Test Manufacturer"
+            tag1Desc = "desc1"
+            tag2Desc = "desc2"
+
+            ; non-localizable
+            DIRID_WINDOWS = 10
+            REG_DWORD     = 0x00010001
+            """)
+
+        self.assertEqual(expectedStr, str(infFile))

--- a/edk2toollib/windows/capsule/inf_generator2_test.py
+++ b/edk2toollib/windows/capsule/inf_generator2_test.py
@@ -14,10 +14,10 @@ from edk2toollib.windows.capsule.inf_generator2 import InfFirmwareSections, InfF
 
 class InfHeaderTest(unittest.TestCase):
     def test_header(self):
-        infStrings = InfStrings()
-        infHeader = InfHeader("InfTest", "1.0.0.1", "01/01/2021", "amd64", "testprovider", "testmfr", infStrings)
+        Strings = InfStrings()
+        Header = InfHeader("InfTest", "1.0.0.1", "01/01/2021", "amd64", "testprovider", "testmfr", Strings)
 
-        expectedStr = textwrap.dedent("""\
+        ExpectedStr = textwrap.dedent("""\
             ;
             ; InfTest
             ; 1.0.0.1
@@ -36,29 +36,29 @@ class InfHeaderTest(unittest.TestCase):
             %MfgName% = Firmware,NTamd64
 
             """)
-        self.assertEqual(expectedStr, str(infHeader))
-        self.assertIn("Provider", infStrings.LocalizableStrings)
-        self.assertEqual("testprovider", infStrings.LocalizableStrings['Provider'])
-        self.assertIn("MfgName", infStrings.LocalizableStrings)
-        self.assertEqual("testmfr", infStrings.LocalizableStrings['MfgName'])
+        self.assertEqual(ExpectedStr, str(Header))
+        self.assertIn("Provider", Strings.LocalizableStrings)
+        self.assertEqual("testprovider", Strings.LocalizableStrings['Provider'])
+        self.assertIn("MfgName", Strings.LocalizableStrings)
+        self.assertEqual("testmfr", Strings.LocalizableStrings['MfgName'])
 
     def test_header_should_throw_for_bad_input(self):
-        infStrings = InfStrings()
+        Strings = InfStrings()
 
         with self.assertRaises(ValueError):
-            InfHeader("InfTest ?? bad", "1.0.0.1", "01/01/2021", "amd64", "testprovider", "testmfr", infStrings)
+            InfHeader("InfTest ?? bad", "1.0.0.1", "01/01/2021", "amd64", "testprovider", "testmfr", Strings)
 
         with self.assertRaises(ValueError):
-            InfHeader("InfTest", "this is not good", "01/01/2021", "amd64", "testprovider", "testmfr", infStrings)
+            InfHeader("InfTest", "this is not good", "01/01/2021", "amd64", "testprovider", "testmfr", Strings)
 
         with self.assertRaises(ValueError):
-            InfHeader("InfTest", "1.0.0.1", "foobar", "amd64", "testprovider", "testmfr", infStrings)
+            InfHeader("InfTest", "1.0.0.1", "foobar", "amd64", "testprovider", "testmfr", Strings)
 
         with self.assertRaises(ValueError):
-            InfHeader("InfTest", "1.0.0.1", "01/01/2021", "foobar", "testprovider", "testmfr", infStrings)
+            InfHeader("InfTest", "1.0.0.1", "01/01/2021", "foobar", "testprovider", "testmfr", Strings)
 
         with self.assertRaises(TypeError):
-            InfHeader(1, "1.0.0.1", "01/01/2021", "amd64", "testprovider", "testmfr", infStrings)
+            InfHeader(1, "1.0.0.1", "01/01/2021", "amd64", "testprovider", "testmfr", Strings)
 
         with self.assertRaises(AttributeError):
             InfHeader("InfTest", "1.0.0.1", "01/01/2021", "amd64", "testprovider", "testmfr", None)
@@ -66,19 +66,19 @@ class InfHeaderTest(unittest.TestCase):
 
 class InfFirmwareTest(unittest.TestCase):
     def test_firmware(self):
-        infStrings = InfStrings()
-        infSourceFiles = InfSourceFiles("diskname", infStrings)
+        Strings = InfStrings()
+        SourceFiles = InfSourceFiles("diskname", Strings)
 
-        infFirmware = InfFirmware(
+        Firmware = InfFirmware(
             "tag",
             "desc",
             "34e094e9-4079-44cd-9450-3f2cb7824c97",
             "0x01000001",
             "test.bin",
-            infStrings,
-            infSourceFiles)
+            Strings,
+            SourceFiles)
 
-        expectedStr = textwrap.dedent("""\
+        ExpectedStr = textwrap.dedent("""\
             [tag_Install.NT]
             CopyFiles = tag_CopyFiles
 
@@ -95,27 +95,27 @@ class InfFirmwareTest(unittest.TestCase):
 
             """)
 
-        self.assertEqual(expectedStr, str(infFirmware))
-        self.assertEqual(infFirmware.Description, "desc")
-        self.assertIn("REG_DWORD", infStrings.NonLocalizableStrings)
-        self.assertEqual("0x00010001", infStrings.NonLocalizableStrings['REG_DWORD'])
-        self.assertIn("test.bin", infSourceFiles.Files)
+        self.assertEqual(ExpectedStr, str(Firmware))
+        self.assertEqual(Firmware.Description, "desc")
+        self.assertIn("REG_DWORD", Strings.NonLocalizableStrings)
+        self.assertEqual("0x00010001", Strings.NonLocalizableStrings['REG_DWORD'])
+        self.assertIn("test.bin", SourceFiles.Files)
 
     def test_rollback_firmware(self):
-        infStrings = InfStrings()
-        infSourceFiles = InfSourceFiles("diskname", infStrings)
+        Strings = InfStrings()
+        SourceFiles = InfSourceFiles("diskname", Strings)
 
-        infFirmware = InfFirmware(
+        Firmware = InfFirmware(
             "tag",
             "desc",
             "34e094e9-4079-44cd-9450-3f2cb7824c97",
             "0x01000001",
             "test.bin",
-            infStrings,
-            infSourceFiles,
+            Strings,
+            SourceFiles,
             Rollback=True)
 
-        expectedStr = textwrap.dedent("""\
+        ExpectedStr = textwrap.dedent("""\
             [tag_Install.NT]
             CopyFiles = tag_CopyFiles
             AddReg = tag_DowngradePolicy_AddReg
@@ -136,28 +136,28 @@ class InfFirmwareTest(unittest.TestCase):
 
             """)
 
-        self.assertEqual(expectedStr, str(infFirmware))
-        self.assertEqual(infFirmware.Description, "desc")
-        self.assertIn("REG_DWORD", infStrings.NonLocalizableStrings)
-        self.assertEqual("0x00010001", infStrings.NonLocalizableStrings['REG_DWORD'])
-        self.assertIn("test.bin", infSourceFiles.Files)
+        self.assertEqual(ExpectedStr, str(Firmware))
+        self.assertEqual(Firmware.Description, "desc")
+        self.assertIn("REG_DWORD", Strings.NonLocalizableStrings)
+        self.assertEqual("0x00010001", Strings.NonLocalizableStrings['REG_DWORD'])
+        self.assertIn("test.bin", SourceFiles.Files)
 
     def test_rollback_firmware_integrity(self):
-        infStrings = InfStrings()
-        infSourceFiles = InfSourceFiles("diskname", infStrings)
+        Strings = InfStrings()
+        SourceFiles = InfSourceFiles("diskname", Strings)
 
-        infFirmware = InfFirmware(
+        Firmware = InfFirmware(
             "tag",
             "desc",
             "34e094e9-4079-44cd-9450-3f2cb7824c97",
             "0x01000001",
             "test.bin",
-            infStrings,
-            infSourceFiles,
+            Strings,
+            SourceFiles,
             Rollback=True,
             IntegrityFile="test2.bin")
 
-        expectedStr = textwrap.dedent("""\
+        ExpectedStr = textwrap.dedent("""\
             [tag_Install.NT]
             CopyFiles = tag_CopyFiles
             AddReg = tag_DowngradePolicy_AddReg
@@ -180,16 +180,16 @@ class InfFirmwareTest(unittest.TestCase):
 
             """)
 
-        self.assertEqual(expectedStr, str(infFirmware))
-        self.assertEqual(infFirmware.Description, "desc")
-        self.assertIn("REG_DWORD", infStrings.NonLocalizableStrings)
-        self.assertEqual("0x00010001", infStrings.NonLocalizableStrings['REG_DWORD'])
-        self.assertIn("test.bin", infSourceFiles.Files)
-        self.assertIn("test2.bin", infSourceFiles.Files)
+        self.assertEqual(ExpectedStr, str(Firmware))
+        self.assertEqual(Firmware.Description, "desc")
+        self.assertIn("REG_DWORD", Strings.NonLocalizableStrings)
+        self.assertEqual("0x00010001", Strings.NonLocalizableStrings['REG_DWORD'])
+        self.assertIn("test.bin", SourceFiles.Files)
+        self.assertIn("test2.bin", SourceFiles.Files)
 
     def test_firmware_should_throw_for_bad_input(self):
-        infStrings = InfStrings()
-        infSourceFiles = InfSourceFiles("diskname", infStrings)
+        Strings = InfStrings()
+        SourceFiles = InfSourceFiles("diskname", Strings)
 
         with self.assertRaises(ValueError):
             InfFirmware(
@@ -198,8 +198,8 @@ class InfFirmwareTest(unittest.TestCase):
                 "34e094e9-4079-44cd-9450-3f2cb7824c97",
                 "0x01000001",
                 "test.bin",
-                infStrings,
-                infSourceFiles,
+                Strings,
+                SourceFiles,
                 Rollback=True,
                 IntegrityFile="test2.bin")
 
@@ -210,8 +210,8 @@ class InfFirmwareTest(unittest.TestCase):
                 "This is not a valid UUID.",
                 "0x01000001",
                 "test.bin",
-                infStrings,
-                infSourceFiles,
+                Strings,
+                SourceFiles,
                 Rollback=True,
                 IntegrityFile="test2.bin")
 
@@ -222,8 +222,8 @@ class InfFirmwareTest(unittest.TestCase):
                 "4e094e9-4079-44cd-9450-3f2cb7824c97",  # a more subtle not-valid UUID.
                 "0x01000001",
                 "test.bin",
-                infStrings,
-                infSourceFiles,
+                Strings,
+                SourceFiles,
                 Rollback=True,
                 IntegrityFile="test2.bin")
 
@@ -234,30 +234,30 @@ class InfFirmwareTest(unittest.TestCase):
                 "34e094e9-4079-44cd-9450-3f2cb7824c97",
                 "foobar",
                 "test.bin",
-                infStrings,
-                infSourceFiles,
+                Strings,
+                SourceFiles,
                 Rollback=True,
                 IntegrityFile="test2.bin")
 
 
 class InfFirmwareSectionsTest(unittest.TestCase):
     def test_one_section(self):
-        infStrings = InfStrings()
-        infSourceFiles = InfSourceFiles("diskname", infStrings)
+        Strings = InfStrings()
+        SourceFiles = InfSourceFiles("diskname", Strings)
 
-        infFirmware = InfFirmware(
+        Firmware = InfFirmware(
             "tag",
             "desc",
             "34e094e9-4079-44cd-9450-3f2cb7824c97",
             "0x01000001",
             "test.bin",
-            infStrings,
-            infSourceFiles)
+            Strings,
+            SourceFiles)
 
-        infSections = InfFirmwareSections('amd64', infStrings)
-        infSections.AddSection(infFirmware)
+        Sections = InfFirmwareSections('amd64', Strings)
+        Sections.AddSection(Firmware)
 
-        expectedStr = textwrap.dedent("""\
+        ExpectedStr = textwrap.dedent("""\
             [Firmware.NTamd64]
             %tagDesc% = tag_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
 
@@ -277,41 +277,41 @@ class InfFirmwareSectionsTest(unittest.TestCase):
 
             """)
 
-        self.assertEqual(expectedStr, str(infSections))
-        self.assertIn("tagDesc", infStrings.LocalizableStrings)
-        self.assertEqual("desc", infStrings.LocalizableStrings['tagDesc'])
-        self.assertIn("test.bin", infSourceFiles.Files)
+        self.assertEqual(ExpectedStr, str(Sections))
+        self.assertIn("tagDesc", Strings.LocalizableStrings)
+        self.assertEqual("desc", Strings.LocalizableStrings['tagDesc'])
+        self.assertIn("test.bin", SourceFiles.Files)
 
-        self.assertIn("REG_DWORD", infStrings.NonLocalizableStrings)
-        self.assertEqual("0x00010001", infStrings.NonLocalizableStrings['REG_DWORD'])
+        self.assertIn("REG_DWORD", Strings.NonLocalizableStrings)
+        self.assertEqual("0x00010001", Strings.NonLocalizableStrings['REG_DWORD'])
 
     def test_two_sections(self):
-        infStrings = InfStrings()
-        infSourceFiles = InfSourceFiles("diskname", infStrings)
+        Strings = InfStrings()
+        SourceFiles = InfSourceFiles("diskname", Strings)
 
-        infFirmware1 = InfFirmware(
+        Firmware1 = InfFirmware(
             "tag1",
             "desc1",
             "34e094e9-4079-44cd-9450-3f2cb7824c97",
             "0x01000001",
             "test1.bin",
-            infStrings,
-            infSourceFiles)
+            Strings,
+            SourceFiles)
 
-        infFirmware2 = InfFirmware(
+        Firmware2 = InfFirmware(
             "tag2",
             "desc2",
             "bec9124f-9934-4ec0-a6ed-b8bc1c91d276",
             "0x01000002",
             "test2.bin",
-            infStrings,
-            infSourceFiles)
+            Strings,
+            SourceFiles)
 
-        infSections = InfFirmwareSections('amd64', infStrings)
-        infSections.AddSection(infFirmware1)
-        infSections.AddSection(infFirmware2)
+        Sections = InfFirmwareSections('amd64', Strings)
+        Sections.AddSection(Firmware1)
+        Sections.AddSection(Firmware2)
 
-        expectedStr = textwrap.dedent("""\
+        ExpectedStr = textwrap.dedent("""\
             [Firmware.NTamd64]
             %tag1Desc% = tag1_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
             %tag2Desc% = tag2_Install,UEFI\\RES_{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
@@ -346,33 +346,33 @@ class InfFirmwareSectionsTest(unittest.TestCase):
 
             """)
 
-        self.assertEqual(expectedStr, str(infSections))
-        self.assertIn("tag1Desc", infStrings.LocalizableStrings)
-        self.assertEqual("desc1", infStrings.LocalizableStrings['tag1Desc'])
-        self.assertIn("test1.bin", infSourceFiles.Files)
-        self.assertIn("tag2Desc", infStrings.LocalizableStrings)
-        self.assertEqual("desc2", infStrings.LocalizableStrings['tag2Desc'])
-        self.assertIn("test2.bin", infSourceFiles.Files)
+        self.assertEqual(ExpectedStr, str(Sections))
+        self.assertIn("tag1Desc", Strings.LocalizableStrings)
+        self.assertEqual("desc1", Strings.LocalizableStrings['tag1Desc'])
+        self.assertIn("test1.bin", SourceFiles.Files)
+        self.assertIn("tag2Desc", Strings.LocalizableStrings)
+        self.assertEqual("desc2", Strings.LocalizableStrings['tag2Desc'])
+        self.assertIn("test2.bin", SourceFiles.Files)
 
-        self.assertIn("REG_DWORD", infStrings.NonLocalizableStrings)
-        self.assertEqual("0x00010001", infStrings.NonLocalizableStrings['REG_DWORD'])
+        self.assertIn("REG_DWORD", Strings.NonLocalizableStrings)
+        self.assertEqual("0x00010001", Strings.NonLocalizableStrings['REG_DWORD'])
 
     def test_firmware_sections_should_throw_for_bad_input(self):
-        infStrings = InfStrings()
+        Strings = InfStrings()
 
         with self.assertRaises(ValueError):
-            InfFirmwareSections('foobar', infStrings)
+            InfFirmwareSections('foobar', Strings)
 
 
 class InfSourceFilesTest(unittest.TestCase):
     def test_source_files(self):
-        infStrings = InfStrings()
-        infSourceFiles = InfSourceFiles("diskname", infStrings)
-        infSourceFiles.addFile("test.bin")
-        infSourceFiles.addFile("test2.bin")
-        infSourceFiles.addFile("test3.bin")
+        Strings = InfStrings()
+        SourceFiles = InfSourceFiles("diskname", Strings)
+        SourceFiles.addFile("test.bin")
+        SourceFiles.addFile("test2.bin")
+        SourceFiles.addFile("test3.bin")
 
-        expectedStr = textwrap.dedent("""\
+        ExpectedStr = textwrap.dedent("""\
             [SourceDisksNames]
             1 = %DiskName%
 
@@ -386,31 +386,31 @@ class InfSourceFilesTest(unittest.TestCase):
 
             """)
 
-        self.assertEqual(expectedStr, str(infSourceFiles))
-        self.assertIn("DiskName", infStrings.LocalizableStrings)
-        self.assertEqual("diskname", infStrings.LocalizableStrings['DiskName'])
-        self.assertIn("DIRID_WINDOWS", infStrings.NonLocalizableStrings)
-        self.assertEqual("10", infStrings.NonLocalizableStrings['DIRID_WINDOWS'])
+        self.assertEqual(ExpectedStr, str(SourceFiles))
+        self.assertIn("DiskName", Strings.LocalizableStrings)
+        self.assertEqual("diskname", Strings.LocalizableStrings['DiskName'])
+        self.assertIn("DIRID_WINDOWS", Strings.NonLocalizableStrings)
+        self.assertEqual("10", Strings.NonLocalizableStrings['DIRID_WINDOWS'])
 
     def test_source_files_should_throw_on_bad_input(self):
-        infStrings = InfStrings()
-        infSourceFiles = InfSourceFiles("diskname", infStrings)
+        Strings = InfStrings()
+        SourceFiles = InfSourceFiles("diskname", Strings)
 
         with self.assertRaises(ValueError):
-            infSourceFiles.addFile("Who Names Files Like This?.bin")
+            SourceFiles.addFile("Who Names Files Like This?.bin")
 
 
 class InfStringsTest(unittest.TestCase):
     def test_inf_strings(self):
-        infStrings = InfStrings()
-        infStrings.addLocalizableString("DiskName", "Firmware Update")
-        infStrings.addLocalizableString("Provider", "Test Provider")
-        infStrings.addLocalizableString("Tag1Desc", "Test Firmware")
+        Strings = InfStrings()
+        Strings.addLocalizableString("DiskName", "Firmware Update")
+        Strings.addLocalizableString("Provider", "Test Provider")
+        Strings.addLocalizableString("Tag1Desc", "Test Firmware")
 
-        infStrings.addNonLocalizableString("DIRID_WINDOWS", "10")
-        infStrings.addNonLocalizableString("REG_DWORD", "0x00010001")
+        Strings.addNonLocalizableString("DIRID_WINDOWS", "10")
+        Strings.addNonLocalizableString("REG_DWORD", "0x00010001")
 
-        expectedStr = textwrap.dedent("""\
+        ExpectedStr = textwrap.dedent("""\
             [Strings]
             ; localizable
             DiskName = "Firmware Update"
@@ -422,49 +422,49 @@ class InfStringsTest(unittest.TestCase):
             REG_DWORD     = 0x00010001
             """)
 
-        self.assertEqual(expectedStr, str(infStrings))
+        self.assertEqual(ExpectedStr, str(Strings))
 
     def test_inf_strings_should_throw_on_bad_input(self):
-        infStrings = InfStrings()
+        Strings = InfStrings()
 
         with self.assertRaises(TypeError):
-            infStrings.addLocalizableString(1, 2)
+            Strings.addLocalizableString(1, 2)
 
         with self.assertRaises(ValueError):
-            infStrings.addLocalizableString("foo bar", "value")
+            Strings.addLocalizableString("foo bar", "value")
 
         with self.assertRaises(ValueError):
-            infStrings.addLocalizableString("ThisIsNotAllowed;", "value")
+            Strings.addLocalizableString("ThisIsNotAllowed;", "value")
 
         with self.assertRaises(TypeError):
-            infStrings.addNonLocalizableString(1, 2)
+            Strings.addNonLocalizableString(1, 2)
 
         with self.assertRaises(ValueError):
-            infStrings.addNonLocalizableString("foo bar", "value")
+            Strings.addNonLocalizableString("foo bar", "value")
 
         with self.assertRaises(ValueError):
-            infStrings.addNonLocalizableString("ThisIsNotAllowed;", "value")
+            Strings.addNonLocalizableString("ThisIsNotAllowed;", "value")
 
 
 class InfFileTest(unittest.TestCase):
     def test_inf_file(self):
-        infFile = InfFile("CapsuleName", "1.0.0.1", "01/01/2021", "Test Provider", "Test Manufacturer")
+        File = InfFile("CapsuleName", "1.0.0.1", "01/01/2021", "Test Provider", "Test Manufacturer")
 
-        infFile.addFirmware(
+        File.addFirmware(
             "tag1",
             "desc1",
             "34e094e9-4079-44cd-9450-3f2cb7824c97",
             "0x01000001",
             "test1.bin")
 
-        infFile.addFirmware(
+        File.addFirmware(
             "tag2",
             "desc2",
             "bec9124f-9934-4ec0-a6ed-b8bc1c91d276",
             "0x01000002",
             "test2.bin")
 
-        expectedStr = textwrap.dedent("""\
+        ExpectedStr = textwrap.dedent("""\
             ;
             ; CapsuleName
             ; 1.0.0.1
@@ -537,12 +537,12 @@ class InfFileTest(unittest.TestCase):
             REG_DWORD     = 0x00010001
             """)
 
-        self.assertEqual(expectedStr, str(infFile))
+        self.assertEqual(ExpectedStr, str(File))
 
     def test_inf_file_rollback(self):
-        infFile = InfFile("CapsuleName", "1.0.0.1", "01/01/2021", "Test Provider", "Test Manufacturer")
+        File = InfFile("CapsuleName", "1.0.0.1", "01/01/2021", "Test Provider", "Test Manufacturer")
 
-        infFile.addFirmware(
+        File.addFirmware(
             "tag1",
             "desc1",
             "34e094e9-4079-44cd-9450-3f2cb7824c97",
@@ -550,7 +550,7 @@ class InfFileTest(unittest.TestCase):
             "test1.bin",
             Rollback=True)
 
-        infFile.addFirmware(
+        File.addFirmware(
             "tag2",
             "desc2",
             "bec9124f-9934-4ec0-a6ed-b8bc1c91d276",
@@ -558,7 +558,7 @@ class InfFileTest(unittest.TestCase):
             "test2.bin",
             Rollback=True)
 
-        expectedStr = textwrap.dedent("""\
+        ExpectedStr = textwrap.dedent("""\
             ;
             ; CapsuleName
             ; 1.0.0.1
@@ -639,13 +639,12 @@ class InfFileTest(unittest.TestCase):
             REG_DWORD     = 0x00010001
             """)
 
-        self.assertEqual(expectedStr, str(infFile))
+        self.assertEqual(ExpectedStr, str(File))
 
     def test_inf_file_rollback_integrity(self):
-        self.maxDiff = None
-        infFile = InfFile("CapsuleName", "1.0.0.1", "01/01/2021", "Test Provider", "Test Manufacturer")
+        File = InfFile("CapsuleName", "1.0.0.1", "01/01/2021", "Test Provider", "Test Manufacturer")
 
-        infFile.addFirmware(
+        File.addFirmware(
             "tag1",
             "desc1",
             "34e094e9-4079-44cd-9450-3f2cb7824c97",
@@ -654,7 +653,7 @@ class InfFileTest(unittest.TestCase):
             Rollback=True,
             IntegrityFile="integrity1.bin")
 
-        infFile.addFirmware(
+        File.addFirmware(
             "tag2",
             "desc2",
             "bec9124f-9934-4ec0-a6ed-b8bc1c91d276",
@@ -663,7 +662,7 @@ class InfFileTest(unittest.TestCase):
             Rollback=True,
             IntegrityFile="integrity2.bin")
 
-        expectedStr = textwrap.dedent("""\
+        ExpectedStr = textwrap.dedent("""\
             ;
             ; CapsuleName
             ; 1.0.0.1
@@ -750,4 +749,4 @@ class InfFileTest(unittest.TestCase):
             REG_DWORD     = 0x00010001
             """)
 
-        self.assertEqual(expectedStr, str(infFile))
+        self.assertEqual(ExpectedStr, str(File))

--- a/edk2toollib/windows/capsule/inf_generator2_test.py
+++ b/edk2toollib/windows/capsule/inf_generator2_test.py
@@ -42,6 +42,27 @@ class InfHeaderTest(unittest.TestCase):
         self.assertIn("MfgName", infStrings.LocalizableStrings)
         self.assertEqual("testmfr", infStrings.LocalizableStrings['MfgName'])
 
+    def test_header_should_throw_for_bad_input(self):
+        infStrings = InfStrings()
+
+        with self.assertRaises(ValueError):
+            InfHeader("InfTest ?? bad", "1.0.0.1", "01/01/2021", "amd64", "testprovider", "testmfr", infStrings)
+
+        with self.assertRaises(ValueError):
+            InfHeader("InfTest", "this is not good", "01/01/2021", "amd64", "testprovider", "testmfr", infStrings)
+
+        with self.assertRaises(ValueError):
+            InfHeader("InfTest", "1.0.0.1", "foobar", "amd64", "testprovider", "testmfr", infStrings)
+
+        with self.assertRaises(ValueError):
+            InfHeader("InfTest", "1.0.0.1", "01/01/2021", "foobar", "testprovider", "testmfr", infStrings)
+
+        with self.assertRaises(TypeError):
+            InfHeader(1, "1.0.0.1", "01/01/2021", "amd64", "testprovider", "testmfr", infStrings)
+
+        with self.assertRaises(AttributeError):
+            InfHeader("InfTest", "1.0.0.1", "01/01/2021", "amd64", "testprovider", "testmfr", None)
+
 
 class InfFirmwareTest(unittest.TestCase):
     def test_firmware(self):
@@ -166,6 +187,58 @@ class InfFirmwareTest(unittest.TestCase):
         self.assertIn("test.bin", infSourceFiles.Files)
         self.assertIn("test2.bin", infSourceFiles.Files)
 
+    def test_firmware_should_throw_for_bad_input(self):
+        infStrings = InfStrings()
+        infSourceFiles = InfSourceFiles("diskname", infStrings)
+
+        with self.assertRaises(ValueError):
+            InfFirmware(
+                "This is not a valid tag name",
+                "desc",
+                "34e094e9-4079-44cd-9450-3f2cb7824c97",
+                "0x01000001",
+                "test.bin",
+                infStrings,
+                infSourceFiles,
+                Rollback=True,
+                IntegrityFile="test2.bin")
+
+        with self.assertRaises(ValueError):
+            InfFirmware(
+                "Tag",
+                "desc",
+                "This is not a valid UUID.",
+                "0x01000001",
+                "test.bin",
+                infStrings,
+                infSourceFiles,
+                Rollback=True,
+                IntegrityFile="test2.bin")
+
+        with self.assertRaises(ValueError):
+            InfFirmware(
+                "Tag",
+                "desc",
+                "4e094e9-4079-44cd-9450-3f2cb7824c97",  # a more subtle not-valid UUID.
+                "0x01000001",
+                "test.bin",
+                infStrings,
+                infSourceFiles,
+                Rollback=True,
+                IntegrityFile="test2.bin")
+
+        with self.assertRaises(ValueError):
+            InfFirmware(
+                "tag",
+                "desc",
+                "34e094e9-4079-44cd-9450-3f2cb7824c97",
+                "foobar",
+                "test.bin",
+                infStrings,
+                infSourceFiles,
+                Rollback=True,
+                IntegrityFile="test2.bin")
+
 
 class InfFirmwareSectionsTest(unittest.TestCase):
     def test_one_section(self):
@@ -284,6 +357,12 @@ class InfFirmwareSectionsTest(unittest.TestCase):
         self.assertIn("REG_DWORD", infStrings.NonLocalizableStrings)
         self.assertEqual("0x00010001", infStrings.NonLocalizableStrings['REG_DWORD'])
 
+    def test_firmware_sections_should_throw_for_bad_input(self):
+        infStrings = InfStrings()
+
+        with self.assertRaises(ValueError):
+            InfFirmwareSections('foobar', infStrings)
+
 
 class InfSourceFilesTest(unittest.TestCase):
     def test_source_files(self):
@@ -313,6 +392,13 @@ class InfSourceFilesTest(unittest.TestCase):
         self.assertIn("DIRID_WINDOWS", infStrings.NonLocalizableStrings)
         self.assertEqual("10", infStrings.NonLocalizableStrings['DIRID_WINDOWS'])
 
+    def test_source_files_should_throw_on_bad_input(self):
+        infStrings = InfStrings()
+        infSourceFiles = InfSourceFiles("diskname", infStrings)
+
+        with self.assertRaises(ValueError):
+            infSourceFiles.addFile("Who Names Files Like This?.bin")
+
 
 class InfStringsTest(unittest.TestCase):
     def test_inf_strings(self):
@@ -337,6 +423,27 @@ class InfStringsTest(unittest.TestCase):
             """)
 
         self.assertEqual(expectedStr, str(infStrings))
+
+    def test_inf_strings_should_throw_on_bad_input(self):
+        infStrings = InfStrings()
+
+        with self.assertRaises(TypeError):
+            infStrings.addLocalizableString(1, 2)
+
+        with self.assertRaises(ValueError):
+            infStrings.addLocalizableString("foo bar", "value")
+
+        with self.assertRaises(ValueError):
+            infStrings.addLocalizableString("ThisIsNotAllowed;", "value")
+
+        with self.assertRaises(TypeError):
+            infStrings.addNonLocalizableString(1, 2)
+
+        with self.assertRaises(ValueError):
+            infStrings.addNonLocalizableString("foo bar", "value")
+
+        with self.assertRaises(ValueError):
+            infStrings.addNonLocalizableString("ThisIsNotAllowed;", "value")
 
 
 class InfFileTest(unittest.TestCase):

--- a/edk2toollib/windows/capsule/inf_generator2_test.py
+++ b/edk2toollib/windows/capsule/inf_generator2_test.py
@@ -368,9 +368,9 @@ class InfSourceFilesTest(unittest.TestCase):
     def test_source_files(self):
         Strings = InfStrings()
         SourceFiles = InfSourceFiles("diskname", Strings)
-        SourceFiles.addFile("test.bin")
-        SourceFiles.addFile("test2.bin")
-        SourceFiles.addFile("test3.bin")
+        SourceFiles.AddFile("test.bin")
+        SourceFiles.AddFile("test2.bin")
+        SourceFiles.AddFile("test3.bin")
 
         ExpectedStr = textwrap.dedent("""\
             [SourceDisksNames]
@@ -397,18 +397,18 @@ class InfSourceFilesTest(unittest.TestCase):
         SourceFiles = InfSourceFiles("diskname", Strings)
 
         with self.assertRaises(ValueError):
-            SourceFiles.addFile("Who Names Files Like This?.bin")
+            SourceFiles.AddFile("Who Names Files Like This?.bin")
 
 
 class InfStringsTest(unittest.TestCase):
     def test_inf_strings(self):
         Strings = InfStrings()
-        Strings.addLocalizableString("DiskName", "Firmware Update")
-        Strings.addLocalizableString("Provider", "Test Provider")
-        Strings.addLocalizableString("Tag1Desc", "Test Firmware")
+        Strings.AddLocalizableString("DiskName", "Firmware Update")
+        Strings.AddLocalizableString("Provider", "Test Provider")
+        Strings.AddLocalizableString("Tag1Desc", "Test Firmware")
 
-        Strings.addNonLocalizableString("DIRID_WINDOWS", "10")
-        Strings.addNonLocalizableString("REG_DWORD", "0x00010001")
+        Strings.AddNonLocalizableString("DIRID_WINDOWS", "10")
+        Strings.AddNonLocalizableString("REG_DWORD", "0x00010001")
 
         ExpectedStr = textwrap.dedent("""\
             [Strings]
@@ -428,36 +428,36 @@ class InfStringsTest(unittest.TestCase):
         Strings = InfStrings()
 
         with self.assertRaises(TypeError):
-            Strings.addLocalizableString(1, 2)
+            Strings.AddLocalizableString(1, 2)
 
         with self.assertRaises(ValueError):
-            Strings.addLocalizableString("foo bar", "value")
+            Strings.AddLocalizableString("foo bar", "value")
 
         with self.assertRaises(ValueError):
-            Strings.addLocalizableString("ThisIsNotAllowed;", "value")
+            Strings.AddLocalizableString("ThisIsNotAllowed;", "value")
 
         with self.assertRaises(TypeError):
-            Strings.addNonLocalizableString(1, 2)
+            Strings.AddNonLocalizableString(1, 2)
 
         with self.assertRaises(ValueError):
-            Strings.addNonLocalizableString("foo bar", "value")
+            Strings.AddNonLocalizableString("foo bar", "value")
 
         with self.assertRaises(ValueError):
-            Strings.addNonLocalizableString("ThisIsNotAllowed;", "value")
+            Strings.AddNonLocalizableString("ThisIsNotAllowed;", "value")
 
 
 class InfFileTest(unittest.TestCase):
     def test_inf_file(self):
         File = InfFile("CapsuleName", "1.0.0.1", "01/01/2021", "Test Provider", "Test Manufacturer")
 
-        File.addFirmware(
+        File.AddFirmware(
             "tag1",
             "desc1",
             "34e094e9-4079-44cd-9450-3f2cb7824c97",
             "0x01000001",
             "test1.bin")
 
-        File.addFirmware(
+        File.AddFirmware(
             "tag2",
             "desc2",
             "bec9124f-9934-4ec0-a6ed-b8bc1c91d276",
@@ -542,7 +542,7 @@ class InfFileTest(unittest.TestCase):
     def test_inf_file_rollback(self):
         File = InfFile("CapsuleName", "1.0.0.1", "01/01/2021", "Test Provider", "Test Manufacturer")
 
-        File.addFirmware(
+        File.AddFirmware(
             "tag1",
             "desc1",
             "34e094e9-4079-44cd-9450-3f2cb7824c97",
@@ -550,7 +550,7 @@ class InfFileTest(unittest.TestCase):
             "test1.bin",
             Rollback=True)
 
-        File.addFirmware(
+        File.AddFirmware(
             "tag2",
             "desc2",
             "bec9124f-9934-4ec0-a6ed-b8bc1c91d276",
@@ -644,7 +644,7 @@ class InfFileTest(unittest.TestCase):
     def test_inf_file_rollback_integrity(self):
         File = InfFile("CapsuleName", "1.0.0.1", "01/01/2021", "Test Provider", "Test Manufacturer")
 
-        File.addFirmware(
+        File.AddFirmware(
             "tag1",
             "desc1",
             "34e094e9-4079-44cd-9450-3f2cb7824c97",
@@ -653,7 +653,7 @@ class InfFileTest(unittest.TestCase):
             Rollback=True,
             IntegrityFile="integrity1.bin")
 
-        File.addFirmware(
+        File.AddFirmware(
             "tag2",
             "desc2",
             "bec9124f-9934-4ec0-a6ed-b8bc1c91d276",

--- a/edk2toollib/windows/capsule/inf_generator2_test.py
+++ b/edk2toollib/windows/capsule/inf_generator2_test.py
@@ -37,10 +37,10 @@ class InfHeaderTest(unittest.TestCase):
 
             """)
         self.assertEqual(expectedStr, str(infHeader))
-        self.assertIn("Provider", infStrings.localizableStrings)
-        self.assertEqual("testprovider", infStrings.localizableStrings['Provider'])
-        self.assertIn("MfgName", infStrings.localizableStrings)
-        self.assertEqual("testmfr", infStrings.localizableStrings['MfgName'])
+        self.assertIn("Provider", infStrings.LocalizableStrings)
+        self.assertEqual("testprovider", infStrings.LocalizableStrings['Provider'])
+        self.assertIn("MfgName", infStrings.LocalizableStrings)
+        self.assertEqual("testmfr", infStrings.LocalizableStrings['MfgName'])
 
 
 class InfFirmwareTest(unittest.TestCase):
@@ -75,10 +75,10 @@ class InfFirmwareTest(unittest.TestCase):
             """)
 
         self.assertEqual(expectedStr, str(infFirmware))
-        self.assertEqual(infFirmware.desc, "desc")
-        self.assertIn("REG_DWORD", infStrings.nonlocalizableStrings)
-        self.assertEqual("0x00010001", infStrings.nonlocalizableStrings['REG_DWORD'])
-        self.assertIn("test.bin", infSourceFiles.files)
+        self.assertEqual(infFirmware.Description, "desc")
+        self.assertIn("REG_DWORD", infStrings.NonLocalizableStrings)
+        self.assertEqual("0x00010001", infStrings.NonLocalizableStrings['REG_DWORD'])
+        self.assertIn("test.bin", infSourceFiles.Files)
 
     def test_rollback_firmware(self):
         infStrings = InfStrings()
@@ -92,7 +92,7 @@ class InfFirmwareTest(unittest.TestCase):
             "test.bin",
             infStrings,
             infSourceFiles,
-            rollback=True)
+            Rollback=True)
 
         expectedStr = textwrap.dedent("""\
             [tag_Install.NT]
@@ -116,10 +116,10 @@ class InfFirmwareTest(unittest.TestCase):
             """)
 
         self.assertEqual(expectedStr, str(infFirmware))
-        self.assertEqual(infFirmware.desc, "desc")
-        self.assertIn("REG_DWORD", infStrings.nonlocalizableStrings)
-        self.assertEqual("0x00010001", infStrings.nonlocalizableStrings['REG_DWORD'])
-        self.assertIn("test.bin", infSourceFiles.files)
+        self.assertEqual(infFirmware.Description, "desc")
+        self.assertIn("REG_DWORD", infStrings.NonLocalizableStrings)
+        self.assertEqual("0x00010001", infStrings.NonLocalizableStrings['REG_DWORD'])
+        self.assertIn("test.bin", infSourceFiles.Files)
 
     def test_rollback_firmware_integrity(self):
         infStrings = InfStrings()
@@ -133,8 +133,8 @@ class InfFirmwareTest(unittest.TestCase):
             "test.bin",
             infStrings,
             infSourceFiles,
-            rollback=True,
-            integrityFile="test2.bin")
+            Rollback=True,
+            IntegrityFile="test2.bin")
 
         expectedStr = textwrap.dedent("""\
             [tag_Install.NT]
@@ -160,11 +160,11 @@ class InfFirmwareTest(unittest.TestCase):
             """)
 
         self.assertEqual(expectedStr, str(infFirmware))
-        self.assertEqual(infFirmware.desc, "desc")
-        self.assertIn("REG_DWORD", infStrings.nonlocalizableStrings)
-        self.assertEqual("0x00010001", infStrings.nonlocalizableStrings['REG_DWORD'])
-        self.assertIn("test.bin", infSourceFiles.files)
-        self.assertIn("test2.bin", infSourceFiles.files)
+        self.assertEqual(infFirmware.Description, "desc")
+        self.assertIn("REG_DWORD", infStrings.NonLocalizableStrings)
+        self.assertEqual("0x00010001", infStrings.NonLocalizableStrings['REG_DWORD'])
+        self.assertIn("test.bin", infSourceFiles.Files)
+        self.assertIn("test2.bin", infSourceFiles.Files)
 
 
 class InfFirmwareSectionsTest(unittest.TestCase):
@@ -205,12 +205,12 @@ class InfFirmwareSectionsTest(unittest.TestCase):
             """)
 
         self.assertEqual(expectedStr, str(infSections))
-        self.assertIn("tagDesc", infStrings.localizableStrings)
-        self.assertEqual("desc", infStrings.localizableStrings['tagDesc'])
-        self.assertIn("test.bin", infSourceFiles.files)
+        self.assertIn("tagDesc", infStrings.LocalizableStrings)
+        self.assertEqual("desc", infStrings.LocalizableStrings['tagDesc'])
+        self.assertIn("test.bin", infSourceFiles.Files)
 
-        self.assertIn("REG_DWORD", infStrings.nonlocalizableStrings)
-        self.assertEqual("0x00010001", infStrings.nonlocalizableStrings['REG_DWORD'])
+        self.assertIn("REG_DWORD", infStrings.NonLocalizableStrings)
+        self.assertEqual("0x00010001", infStrings.NonLocalizableStrings['REG_DWORD'])
 
     def test_two_sections(self):
         infStrings = InfStrings()
@@ -274,15 +274,15 @@ class InfFirmwareSectionsTest(unittest.TestCase):
             """)
 
         self.assertEqual(expectedStr, str(infSections))
-        self.assertIn("tag1Desc", infStrings.localizableStrings)
-        self.assertEqual("desc1", infStrings.localizableStrings['tag1Desc'])
-        self.assertIn("test1.bin", infSourceFiles.files)
-        self.assertIn("tag2Desc", infStrings.localizableStrings)
-        self.assertEqual("desc2", infStrings.localizableStrings['tag2Desc'])
-        self.assertIn("test2.bin", infSourceFiles.files)
+        self.assertIn("tag1Desc", infStrings.LocalizableStrings)
+        self.assertEqual("desc1", infStrings.LocalizableStrings['tag1Desc'])
+        self.assertIn("test1.bin", infSourceFiles.Files)
+        self.assertIn("tag2Desc", infStrings.LocalizableStrings)
+        self.assertEqual("desc2", infStrings.LocalizableStrings['tag2Desc'])
+        self.assertIn("test2.bin", infSourceFiles.Files)
 
-        self.assertIn("REG_DWORD", infStrings.nonlocalizableStrings)
-        self.assertEqual("0x00010001", infStrings.nonlocalizableStrings['REG_DWORD'])
+        self.assertIn("REG_DWORD", infStrings.NonLocalizableStrings)
+        self.assertEqual("0x00010001", infStrings.NonLocalizableStrings['REG_DWORD'])
 
 
 class InfSourceFilesTest(unittest.TestCase):
@@ -308,10 +308,10 @@ class InfSourceFilesTest(unittest.TestCase):
             """)
 
         self.assertEqual(expectedStr, str(infSourceFiles))
-        self.assertIn("DiskName", infStrings.localizableStrings)
-        self.assertEqual("diskname", infStrings.localizableStrings['DiskName'])
-        self.assertIn("DIRID_WINDOWS", infStrings.nonlocalizableStrings)
-        self.assertEqual("10", infStrings.nonlocalizableStrings['DIRID_WINDOWS'])
+        self.assertIn("DiskName", infStrings.LocalizableStrings)
+        self.assertEqual("diskname", infStrings.LocalizableStrings['DiskName'])
+        self.assertIn("DIRID_WINDOWS", infStrings.NonLocalizableStrings)
+        self.assertEqual("10", infStrings.NonLocalizableStrings['DIRID_WINDOWS'])
 
 
 class InfStringsTest(unittest.TestCase):
@@ -321,8 +321,8 @@ class InfStringsTest(unittest.TestCase):
         infStrings.addLocalizableString("Provider", "Test Provider")
         infStrings.addLocalizableString("Tag1Desc", "Test Firmware")
 
-        infStrings.addNonlocalizableString("DIRID_WINDOWS", "10")
-        infStrings.addNonlocalizableString("REG_DWORD", "0x00010001")
+        infStrings.addNonLocalizableString("DIRID_WINDOWS", "10")
+        infStrings.addNonLocalizableString("REG_DWORD", "0x00010001")
 
         expectedStr = textwrap.dedent("""\
             [Strings]
@@ -441,7 +441,7 @@ class InfFileTest(unittest.TestCase):
             "34e094e9-4079-44cd-9450-3f2cb7824c97",
             "0x01000001",
             "test1.bin",
-            rollback=True)
+            Rollback=True)
 
         infFile.addFirmware(
             "tag2",
@@ -449,7 +449,7 @@ class InfFileTest(unittest.TestCase):
             "bec9124f-9934-4ec0-a6ed-b8bc1c91d276",
             "0x01000002",
             "test2.bin",
-            rollback=True)
+            Rollback=True)
 
         expectedStr = textwrap.dedent("""\
             ;
@@ -544,8 +544,8 @@ class InfFileTest(unittest.TestCase):
             "34e094e9-4079-44cd-9450-3f2cb7824c97",
             "0x01000001",
             "test1.bin",
-            rollback=True,
-            integrityFile="integrity1.bin")
+            Rollback=True,
+            IntegrityFile="integrity1.bin")
 
         infFile.addFirmware(
             "tag2",
@@ -553,8 +553,8 @@ class InfFileTest(unittest.TestCase):
             "bec9124f-9934-4ec0-a6ed-b8bc1c91d276",
             "0x01000002",
             "test2.bin",
-            rollback=True,
-            integrityFile="integrity2.bin")
+            Rollback=True,
+            IntegrityFile="integrity2.bin")
 
         expectedStr = textwrap.dedent("""\
             ;

--- a/edk2toollib/windows/capsule/inf_generator2_test.py
+++ b/edk2toollib/windows/capsule/inf_generator2_test.py
@@ -21,7 +21,7 @@ class InfHeaderTest(unittest.TestCase):
             ;
             ; InfTest
             ; 1.0.0.1
-            ; Copyright (C) Microsoft Corporation. All rights Reserved.
+            ; Copyright (C) Microsoft Corporation. All Rights Reserved.
             ;
             [Version]
             Signature="$WINDOWS NT$"
@@ -361,7 +361,7 @@ class InfFileTest(unittest.TestCase):
             ;
             ; CapsuleName
             ; 1.0.0.1
-            ; Copyright (C) Microsoft Corporation. All rights Reserved.
+            ; Copyright (C) Microsoft Corporation. All Rights Reserved.
             ;
             [Version]
             Signature="$WINDOWS NT$"
@@ -455,7 +455,7 @@ class InfFileTest(unittest.TestCase):
             ;
             ; CapsuleName
             ; 1.0.0.1
-            ; Copyright (C) Microsoft Corporation. All rights Reserved.
+            ; Copyright (C) Microsoft Corporation. All Rights Reserved.
             ;
             [Version]
             Signature="$WINDOWS NT$"
@@ -560,7 +560,7 @@ class InfFileTest(unittest.TestCase):
             ;
             ; CapsuleName
             ; 1.0.0.1
-            ; Copyright (C) Microsoft Corporation. All rights Reserved.
+            ; Copyright (C) Microsoft Corporation. All Rights Reserved.
             ;
             [Version]
             Signature="$WINDOWS NT$"


### PR DESCRIPTION
Add inf_generator2 which supports generating multi-node capsules (targeting more than one ESRT).  This permits building capsules that can target more than one ESRT node, which is useful in scenarios where e.g. system configuration may require a slightly modified payload for the same firmware. 

A sample output:
```
;
; CapsuleName
; 1.0.0.1
; Copyright (C) Microsoft Corporation. All rights Reserved.
;
[Version]
Signature="$WINDOWS NT$"
Class=Firmware
ClassGuid={f2e7dd72-6468-4e36-b6f1-6488f42c1b52}
Provider=%Provider%
DriverVer=01/01/2021,1.0.0.1
PnpLockdown=1
CatalogFile=CapsuleName.cat

[Manufacturer]
%MfgName%=Firmware,NTamd64

[Firmware.NTamd64]
%tag1Desc% = tag1_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
%tag2Desc% = tag2_Install,UEFI\\RES_{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}

[tag1_Install.NT]
CopyFiles = tag1_CopyFiles
AddReg = tag1_DowngradePolicy_AddReg

[tag1_DowngradePolicy_AddReg]
HKLM,SYSTEM\\CurrentControlSet\\Control\\FirmwareResources\\{34e094e9-4079-44cd-9450-3f2cb7824c97},Policy,%REG_DWORD%,1

[tag1_CopyFiles]
test1.bin
integrity1.bin

[tag1_Install.NT.Hw]
AddReg = tag1_AddReg

[tag1_AddReg]
HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
HKR,,FirmwareFilename,,test1.bin
HKR,,FirmwareIntegrityFilename,,integrity1.bin

[tag2_Install.NT]
CopyFiles = tag2_CopyFiles
AddReg = tag2_DowngradePolicy_AddReg

[tag2_DowngradePolicy_AddReg]
HKLM,SYSTEM\\CurrentControlSet\\Control\\FirmwareResources\\{bec9124f-9934-4ec0-a6ed-b8bc1c91d276},Policy,%REG_DWORD%,1

[tag2_CopyFiles]
test2.bin
integrity2.bin

[tag2_Install.NT.Hw]
AddReg = tag2_AddReg

[tag2_AddReg]
HKR,,FirmwareId,,{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
HKR,,FirmwareVersion,%REG_DWORD%,0x1000002
HKR,,FirmwareFilename,,test2.bin
HKR,,FirmwareIntegrityFilename,,integrity2.bin

[SourceDisksNames]
1 = %DiskName%

[SourceDisksFiles]
test1.bin=1
integrity1.bin=1
test2.bin=1
integrity2.bin=1

[DestinationDirs]
DefaultDestDir = %DIRID_WINDOWS%,Firmware ; %SystemRoot%\\Firmware

[Strings]
; localizable
DiskName = Firmware Update
Provider = Test Provider
MfgName  = Test Manufacturer
tag1Desc = desc1
tag2Desc = desc2

; non-localizable
DIRID_WINDOWS = 10
REG_DWORD     = 0x00010001
```