### PR TITLE
Stop buildreport_parser.py from attempting to search for binary compo…

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/buildreport_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/buildreport_parser.py
@@ -290,7 +290,7 @@ class BuildReport(object):
 
                 # Take absolute path and convert to EDK build path
                 RelativePath = self.PathConverter.GetEdk2RelativePathFromAbsolutePath(i)
-                if(RelativePath is not None):
+                if (RelativePath is not None) and ("Binaries" not in RelativePath):
                     comp = self.FindComponentByInfPath(RelativePath)
                     if comp is not None:
                         comp.FvName = FvName


### PR DESCRIPTION
…nents in module list.