### PR TITLE
Downgrade pipeline to windows-2019

### DIFF
--- a/azure-pipelines/windows-test-pr-ci.yml
+++ b/azure-pipelines/windows-test-pr-ci.yml
@@ -22,7 +22,7 @@ pr:
 jobs:
 - template: azure-pipelines/templates/build-test-job.yml@pytool_extensions
   parameters:
-    vm_image: 'windows-latest'
+    vm_image: 'windows-2019'
     root_package_folder: "edk2toollib"
     name: 'windows'
     codecov_enabled: true


### PR DESCRIPTION
windows-2022 does not have WDK installed due to there not being an official release for windows 11. WDK is necessary to pass ci, so downgrading to windows-2019 until there is a proper WDK for windows-2022.