### PR TITLE
Add long-line handling to build report parser for INF paths

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/buildreport_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/buildreport_parser.py
@@ -143,6 +143,9 @@ class ModuleSummary(object):
                                 logging.debug("Parsing Mod: %s" % value)
                                 self.Name = value
                             elif(key == "module inf path"):
+                                while(".inf" not in value.lower()):
+                                    i += 1
+                                    value += self._RawContent[i].strip()
                                 self.InfPath = value.replace("\\", "/")
                             elif(key == "file guid"):
                                 self.Guid = value


### PR DESCRIPTION
The Build Report will line break after 120 characters which causes parser errors when Module INF Paths are longer than 101 characters. This change reads additional lines until the Module INF Path contains ".inf".