### PR TITLE
Downgrade azure-pipelines-release.yml vm to windows-2019

### DIFF
--- a/azure-pipelines/azure-pipelines-release.yml
+++ b/azure-pipelines/azure-pipelines-release.yml
@@ -24,7 +24,7 @@ pr: none  # not a pr target
 jobs:
 - template: azure-pipelines/templates/build-test-job.yml@pytool_extensions
   parameters:
-    vm_image: 'windows-latest'
+    vm_image: 'windows-2019'
     pypi_auth_feed: 'Pypi-edk2-pytool-library'
     root_package_folder: "edk2toollib"
     name: 'windows'


### PR DESCRIPTION
azure-pipelines-release.yml fails due to windows-latest (windows-2022) VM not currently having a WDK. Due to this, release builds fail and is not distributed to PyPI. Downgrading to windows-2019 until windows-2022 includes WDK