### PR TITLE
Introduce close_fds argument in RunCmd

### DIFF
--- a/edk2toollib/utility_functions.py
+++ b/edk2toollib/utility_functions.py
@@ -167,11 +167,14 @@ def timing(f):
 #                                     return code is not zero.
 # @param encodingErrors - may be given to set the desired error handling for encoding errors decoding cmd output.
 #                         Default is 'strict'.
+# @param close_fds - If True, file descriptors are closed before the command is run.
+#                    Default is True.
 #
 # @return returncode of called cmd
 ####
 def RunCmd(cmd, parameters, capture=True, workingdir=None, outfile=None, outstream=None, environ=None,
-           logging_level=logging.INFO, raise_exception_on_nonzero=False, encodingErrors='strict'):
+           logging_level=logging.INFO, raise_exception_on_nonzero=False, encodingErrors='strict',
+           close_fds=True):
     cmd = cmd.strip('"\'')
     if " " in cmd:
         cmd = '"' + cmd + '"'
@@ -183,7 +186,8 @@ def RunCmd(cmd, parameters, capture=True, workingdir=None, outfile=None, outstre
     logging.log(logging_level, "------------------------------------------------")
     logging.log(logging_level, "--------------Cmd Output Starting---------------")
     logging.log(logging_level, "------------------------------------------------")
-    c = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=workingdir, shell=True, env=environ)
+    c = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                         cwd=workingdir, shell=True, env=environ, close_fds=close_fds)
     if(capture):
         thread = PropagatingThread(target=reader, args=(outfile, outstream, c.stdout, logging_level, encodingErrors))
         thread.start()

--- a/license.txt
+++ b/license.txt
@@ -1,5 +1,6 @@
 Copyright (c) 2019, TianoCore and contributors.  All rights reserved.
 Copyright (c) Microsoft All rights reserved.
+Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 


### PR DESCRIPTION
This is necessary to enable GNU make's job control to pass through
commands like stuart_build.  GNU make's job control is implemented using
tokens on file descriptor.  If the file descriptors remain open, a GNU
make calling stuart_build can communicate with a GNU make called by
stuart_build.  However, Python's Popen closes file descriptors by
default.

This change adds a close_fds argument to RunCmd, which passes through to
Popen.  It defaults to True, which is Popen's default value, so existing
behaviors are not changed.

A similar change will be proposed in edk2-pytool-extensions.