### PR TITLE
Bugfix - Standardizing separators for packages paths

### DIFF
--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -108,16 +108,16 @@ class Edk2Path(object):
 
         if relpath is None:
             return None
-        relpath = Path(relpath)
-        abspath = Path(self.WorkspacePath) / relpath
-        if abspath.exists():
-            return str(abspath)
+        relpath = relpath.replace("/", os.sep).replace('\\', os.sep)
+        abspath = os.path.join(self.WorkspacePath, relpath)
+        if os.path.exists(abspath):
+            return abspath
 
         for package_path in self.PackagePathList:
-            package_path = Path(package_path)
-            abspath = package_path / relpath
-            if abspath.exists():
-                return str(abspath)
+            package_path = package_path.replace("/", os.sep).replace('\\', os.sep)
+            abspath = os.path.join(package_path, relpath)
+            if(os.path.exists(abspath)):
+                return abspath
         if log_errors:
             self.logger.error("Failed to convert Edk2Relative Path to an Absolute Path on this system.")
             self.logger.error("Relative Path: %s" % relpath)

--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -29,7 +29,7 @@ class Edk2Path(object):
                 Entries can be Absolute path, workspace relative path, or CWD relative.
             error_on_invalid_pp: default value is True. If packages path value is invalid raise exception
         """
-
+        ws = ws.replace("/", os.sep).replace('\\', os.sep)
         self.WorkspacePath = ws
         self.logger = logging.getLogger("Edk2Path")
         if(not os.path.isabs(ws)):
@@ -42,6 +42,7 @@ class Edk2Path(object):
         # Set PackagePath
         self.PackagePathList = list()
         for a in packagepathlist:
+            a = a.replace("/", os.sep).replace('\\', os.sep)
             if(os.path.isabs(a)):
                 self.PackagePathList.append(a)
             else:
@@ -55,6 +56,7 @@ class Edk2Path(object):
 
         error = False
         for a in self.PackagePathList[:]:
+            a = a.replace("/", os.sep).replace('\\', os.sep)
             if(not os.path.isdir(a)):
                 self.logger.log(logging.ERROR if error_on_invalid_pp else logging.WARNING,
                                 "Invalid package path entry {0}".format(a))
@@ -121,7 +123,6 @@ class Edk2Path(object):
         if log_errors:
             self.logger.error("Failed to convert Edk2Relative Path to an Absolute Path on this system.")
             self.logger.error("Relative Path: %s" % relpath)
-
         return None
 
     # Find the package this path belongs to using

--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -108,15 +108,16 @@ class Edk2Path(object):
 
         if relpath is None:
             return None
-        relpath = relpath.replace("/", os.sep)
-        abspath = os.path.join(self.WorkspacePath, relpath)
-        if os.path.exists(abspath):
-            return abspath
+        relpath = Path(relpath)
+        abspath = Path(self.WorkspacePath) / relpath
+        if abspath.exists():
+            return str(abspath)
 
-        for a in self.PackagePathList:
-            abspath = os.path.join(a, relpath)
-            if(os.path.exists(abspath)):
-                return abspath
+        for package_path in self.PackagePathList:
+            package_path = Path(package_path)
+            abspath = package_path / relpath
+            if abspath.exists():
+                return str(abspath)
         if log_errors:
             self.logger.error("Failed to convert Edk2Relative Path to an Absolute Path on this system.")
             self.logger.error("Relative Path: %s" % relpath)

--- a/edk2toollib/uefi/edk2/path_utilities_test.py
+++ b/edk2toollib/uefi/edk2/path_utilities_test.py
@@ -655,10 +655,10 @@ class PathUtilitiesTest(unittest.TestCase):
 
         File layout:
 
-         root/                  <-- current working directory (self.tmp)
-            folder_ws/           <-- workspace root
-                folder_pp/       <-- packages path
-                    PPTestPkg/   <-- A edk2 package
+         root/                             <-- current working directory (self.tmp)
+            folder_ws/                     <-- workspace root
+                folder_pp1/                <-- packages path
+                    PPTestPkg/             <-- A edk2 package
                         PPTestPkg.DEC
                         module1/
                             module1.INF
@@ -666,7 +666,16 @@ class PathUtilitiesTest(unittest.TestCase):
                             module2.INF
                             X64/
                                 TestFile.c
-                WSTestPkg/   <-- A edk2 package
+                folder_pp2/                <-- packages path
+                    PP2TestPkg/            <-- A edk2 package
+                        PP2TestPkg.dec
+                        module1/
+                            module1.inf
+                        module2/
+                            module2.inf
+                            X64/
+                                TestFile.c
+                WSTestPkg/                 <-- A edk2 package
                     WSTestPkg.dec
                     module1/
                         module1.inf
@@ -678,18 +687,29 @@ class PathUtilitiesTest(unittest.TestCase):
         ws_rel = "folder_ws"
         ws_abs = os.path.join(self.tmp, ws_rel)
         os.mkdir(ws_abs)
-        folder_pp_rel = "pp1"
-        folder_pp1_abs = os.path.join(ws_abs, folder_pp_rel)
+        folder_pp1_rel = "pp1"
+        folder_pp1_abs = os.path.join(ws_abs, folder_pp1_rel)
         os.mkdir(folder_pp1_abs)
+        folder_pp2_rel = "pp2"
+        wrong_separator = '\\' if '/' == os.sep else '/'
+        folder_pp2_abs = wrong_separator.join([ws_abs, folder_pp2_rel])
+        os.mkdir(folder_pp2_abs)
         ws_p_name = "WSTestPkg"
         ws_pkg_abs = self._make_edk2_package_helper(ws_abs, ws_p_name)
         pp_p_name = "PPTestPkg"
         pp_pkg_abs = self._make_edk2_package_helper(folder_pp1_abs, pp_p_name, extension_case_lower=False)
-        pathobj = Edk2Path(ws_abs, [folder_pp1_abs])
+        pp2_p_name = "PP2TestPkg"
+        self._make_edk2_package_helper(folder_pp2_abs, pp2_p_name)
+        pathobj = Edk2Path(ws_abs, [folder_pp1_abs, folder_pp2_abs])
 
         # file in packages path
         ep = os.path.join(pp_pkg_abs, "module1", "module1.INF")
         rp = f"{pp_p_name}/module1/module1.INF"
+        self.assertEqual(pathobj.GetAbsolutePathOnThisSystemFromEdk2RelativePath(rp), ep)
+
+        # separators are normalized
+        ep = os.path.join(ws_abs, folder_pp2_rel, pp2_p_name, "module1", "module1.inf")
+        rp = f"{pp2_p_name}/module1/module1.inf"
         self.assertEqual(pathobj.GetAbsolutePathOnThisSystemFromEdk2RelativePath(rp), ep)
 
         # file in workspace

--- a/edk2toollib/uefi/edk2/path_utilities_test.py
+++ b/edk2toollib/uefi/edk2/path_utilities_test.py
@@ -692,7 +692,8 @@ class PathUtilitiesTest(unittest.TestCase):
         os.mkdir(folder_pp1_abs)
         folder_pp2_rel = "pp2"
         wrong_separator = '\\' if '/' == os.sep else '/'
-        folder_pp2_abs = wrong_separator.join([ws_abs, folder_pp2_rel])
+        folder_pp2_abs_wrong_separator = wrong_separator.join([ws_abs, folder_pp2_rel])
+        folder_pp2_abs = os.path.join(ws_abs, folder_pp2_rel)
         os.mkdir(folder_pp2_abs)
         ws_p_name = "WSTestPkg"
         ws_pkg_abs = self._make_edk2_package_helper(ws_abs, ws_p_name)
@@ -700,7 +701,7 @@ class PathUtilitiesTest(unittest.TestCase):
         pp_pkg_abs = self._make_edk2_package_helper(folder_pp1_abs, pp_p_name, extension_case_lower=False)
         pp2_p_name = "PP2TestPkg"
         self._make_edk2_package_helper(folder_pp2_abs, pp2_p_name)
-        pathobj = Edk2Path(ws_abs, [folder_pp1_abs, folder_pp2_abs])
+        pathobj = Edk2Path(ws_abs, [folder_pp1_abs, folder_pp2_abs_wrong_separator])
 
         # file in packages path
         ep = os.path.join(pp_pkg_abs, "module1", "module1.INF")


### PR DESCRIPTION
This makes the paths returned by `GetAbsolutePathOnThisSystemFromEdk2RelativePath` have consistent separators. Previously, if `self.PackagePathList` had `/`s as separators, the returned path would have both `/` and `\` as separators. This can cause issues with other tools.