### PR TITLE
Re-enable GetEdk2RelativePathFromAbsolutePath() to determine relative path from non existent absolute path

### DIFF
--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -86,9 +86,18 @@ class Edk2Path(object):
         '''
         if abspath is None:
             return None
+        
+        # Path does not need to exist; therefore find the first parent 
+        # directory that exists and use that to generate the relative path. 
+        temp_path = Path(abspath)
+        while not temp_path.exists():
+            if temp_path is temp_path.parent:
+                return None
+            temp_path = temp_path.parent
+
         package = self.GetContainingPackage(abspath)
         if package is not None:
-            relpath = abspath[abspath.find(package):]
+            relpath = abspath[str(temp_path).find(package):]
             relpath = relpath.replace(os.sep, "/")
             return relpath.lstrip("/")
         else:


### PR DESCRIPTION
Recent changes to ```GetEdk2RelativePathFromAbsolutePath()``` resulted in runtime errors when calling the function on an absolute path that did not exist. This is a bug as before the change was made, ```GetEdk2RelativePathFromAbosolutePath()``` was able to generate a relative path regardless of if the absolute path existed, as long as a parent directory of the absolute path did exist.

Due to this, PR evaluation broke for situations where a file or directory was removed, as the relative path for the removed file/directory could not be determined, thus the package containing the removed directory could not be tested.

This change adds the back in the ability to determine a relative path for a non existent absolute path. Additionally, a test case was added to ensure this remains possible in the future.