### PR TITLE
Update Cspell configuration to allow compound words

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -11,6 +11,7 @@
     "ignorePaths": [
         "*.exe"
     ],
+    "allowCompoundWords": true,
     "ignoreWords": [
     ],
     "words": [


### PR DESCRIPTION
In a recent update to Cspell, allowing compound words became a configuration setting that was set to false be default. Originally compound words were treated as allowed. This change sets the value of AllowCompoundWords to true to match previous requirements.