### PR TITLE
Multiple fixes to gitignore_parser.py

### DIFF
--- a/edk2toollib/gitignore_parser.py
+++ b/edk2toollib/gitignore_parser.py
@@ -140,7 +140,7 @@ def rule_from_pattern(pattern, base_path=None, source=None):
     if anchored:
         # DeprecationWarning: Flags not at the start of the expression
         # Must ensure (?ms) is at the front of the regex, so we can no
-        # longer put ^ in the beggining of a regex string.
+        # longer put ^ in the beginning of a regex string.
         # OLD example: ^(?ms)\.eggs$
         # NEW Example: (?ms)^\.eggs$
         # regex = ''.join(['^', regex])

--- a/edk2toollib/gitignore_parser.py
+++ b/edk2toollib/gitignore_parser.py
@@ -45,8 +45,8 @@ SOFTWARE.
 
 def handle_negation(file_path, rules):
     """ allows `matched` value override if negation is true, otherwise
-    it matched will stay true. Used for ensuring rules with ! will override
-    the value back to false.
+    `matched` cannot be overwritten with an exception. Used for ensuring rules
+    with ! will override a previous true result back to false.
     """
     matched = False
     for rule in rules:

--- a/edk2toollib/gitignore_parser.py
+++ b/edk2toollib/gitignore_parser.py
@@ -3,7 +3,7 @@ from os.path import dirname, abspath
 import re
 import os
 import collections
-import pprint
+
 """
 gitignore parser configured to work for edk2-pytool-library
 """

--- a/edk2toollib/gitignore_parser.py
+++ b/edk2toollib/gitignore_parser.py
@@ -3,6 +3,7 @@ from os.path import dirname, abspath
 import re
 import os
 import collections
+import pprint
 """
 gitignore parser configured to work for edk2-pytool-library
 """
@@ -123,7 +124,13 @@ def rule_from_pattern(pattern, base_path=None, source=None):
         pattern
     )
     if anchored:
-        regex = ''.join(['^', regex])
+        # DeprecationWarning: Flags not at the start of the expression
+        # Must ensure (?ms) is at the front of the regex, so we can no
+        # longer put ^ at the fron.
+        # OLD example: ^(?ms)\.eggs$
+        # NEW Example: (?ms)^\.eggs$
+        # regex = ''.join(['^', regex])
+        regex = regex[:5] + '^' + regex[5:]
     return IgnoreRule(
         pattern=orig_pattern,
         regex=regex,
@@ -177,8 +184,8 @@ def fnmatch_pathname_to_regex(pattern):
     seps = [re.escape(os.sep)]
     if os.altsep is not None:
         seps.append(re.escape(os.altsep))
-    seps_group = '[' + '|'.join(seps) + ']'
-    nonsep = r'[^{}]'.format('|'.join(seps))
+    seps_group = r'[{}]'.format(''.join(seps))
+    nonsep = r'[^{}]'.format(''.join(seps))
 
     res = []
     while i < n:

--- a/edk2toollib/gitignore_parser.py
+++ b/edk2toollib/gitignore_parser.py
@@ -44,6 +44,21 @@ SOFTWARE.
 '''
 
 
+def handle_negation(file_path, rules):
+    """ allows `matched` value override if negation is true, otherwise
+    it matched will stay true. Used for ensuring rules with ! will override
+    the value back to false.
+    """
+    matched = False
+    for rule in rules:
+        if rule.match(file_path):
+            if rule.negation:
+                matched = False
+            else:
+                matched = True
+    return matched
+
+
 def parse_gitignore_file(full_path, base_dir=None):
     """ parse a gitignore file
     """
@@ -66,7 +81,7 @@ def parse_gitignore_lines(lines: list, full_path: str, base_dir: str):
                                  source=(full_path, counter))
         if rule:
             rules.append(rule)
-    return lambda file_path: any(r.match(file_path) for r in rules)
+    return lambda file_path: handle_negation(file_path, rules)
 
 
 def rule_from_pattern(pattern, base_path=None, source=None):

--- a/edk2toollib/gitignore_parser.py
+++ b/edk2toollib/gitignore_parser.py
@@ -3,7 +3,6 @@ from os.path import dirname, abspath
 import re
 import os
 import collections
-
 """
 gitignore parser configured to work for edk2-pytool-library
 """
@@ -141,7 +140,7 @@ def rule_from_pattern(pattern, base_path=None, source=None):
     if anchored:
         # DeprecationWarning: Flags not at the start of the expression
         # Must ensure (?ms) is at the front of the regex, so we can no
-        # longer put ^ at the fron.
+        # longer put ^ in the beggining of a regex string.
         # OLD example: ^(?ms)\.eggs$
         # NEW Example: (?ms)^\.eggs$
         # regex = ''.join(['^', regex])

--- a/edk2toollib/gitingore_parser_test.py
+++ b/edk2toollib/gitingore_parser_test.py
@@ -30,6 +30,10 @@ def BuildGitIgnore(root):
         gitignore.write("*.exe\n")
         gitignore.write("!important.exe\n")
         gitignore.write("/BaseTools/BaseToolsBuild/\n")
+        gitignore.write("/docs/**/*.txt\n")
+        gitignore.write("/reader/*\n")
+        gitignore.write("out?.log\n")
+        gitignore.write("log[0-9].txt\n")
     return path
 
 
@@ -52,6 +56,14 @@ class GitIgnoreParserTest(unittest.TestCase):
             # /Build/
             self.assertTrue(rule_tester(os.path.join(root, "Build")))
             self.assertFalse(rule_tester(os.path.join(root, "T", "Build")))
+
+            # Test a rule which specifies that a specific folder is not
+            # filtered, but the contents of the folder is filtered
+
+            # Example ine in a .gitignore
+            # /reader/*
+            self.assertFalse(rule_tester(os.path.join(root, "reader")))
+            self.assertTrue(rule_tester(os.path.join(root, "reader", "testing.txt")))
 
             # Test a rule which specifies that a folder at any depth from the
             # root is correclty filtered.
@@ -87,6 +99,33 @@ class GitIgnoreParserTest(unittest.TestCase):
             self.assertTrue(rule_tester(os.path.join(root, 'T', 'test.exe')))
             self.assertFalse(rule_tester(os.path.join(root, 'important.exe')))
             self.assertFalse(rule_tester(os.path.join(root, 'T', 'important.exe')))
+
+            # Test a rule which specifies a file type in any directory under a
+            # specific folder are correctly filtered.
+
+            # Example line in a .gitignore
+            # /docs/**/*.txt
+            self.assertTrue(rule_tester(os.path.join(root, 'docs', 'notes.txt')))
+            self.assertFalse(rule_tester(os.path.join(root, 'docs', 'Readme.md')))
+            self.assertTrue(rule_tester(os.path.join(root, 'docs', 'developing', 'notes.txt')))
+            self.assertFalse(rule_tester(os.path.join(root, 'docs', 'developing', 'Readme.md')))
+
+            # Test a rule which specifies a file with a specific naming convention be
+            # correctly filtered
+
+            # Example line in a .gitignore
+            # out?.log
+
+            self.assertTrue(rule_tester(os.path.join(root, 'out1.log')))
+            self.assertTrue(rule_tester(os.path.join(root, 'outF.log')))
+            self.assertFalse(rule_tester(os.path.join(root, 'out11.log')))
+
+            # log[0-9].txt
+            self.assertTrue(rule_tester(os.path.join(root, 'log1.txt')))
+            self.assertFalse(rule_tester(os.path.join(root, 'logF.txt')))
+            self.assertFalse(rule_tester(os.path.join(root, 'log11.txt')))
+
+            # logged[!F]
 
     def test_rule_from_pattern(self):
 

--- a/edk2toollib/gitingore_parser_test.py
+++ b/edk2toollib/gitingore_parser_test.py
@@ -33,82 +33,41 @@ def BuildGitIgnore(root):
 
 class GitIgnoreParserTest(unittest.TestCase):
 
-    def test_filter_directory_at_base(self):
+    def test_gitignoreparser_filter(self):
         '''
-        Ensure the gitignore parser works properly when a rule specifies that
-        a folder at the base of the directory is filtered.
-
-        Example: /Build/
+        Ensure the gitignore parser filters files and folders correctly per
+        what is specified in the parsed .gitignore file.
         '''
         with tempfile.TemporaryDirectory() as root:
 
             gitignore_path = BuildGitIgnore(root)
             rule_tester = gitignore_parser.parse_gitignore_file(gitignore_path)
 
-            # Windows
-            self.assertTrue(rule_tester(f'{root}\\Build'))
-            self.assertFalse(rule_tester(f'{root}\\T\\Build'))
+            # Test a rule which specifies that a specific folder at root is
+            # correctly filtered:
 
-            # Linux
-            self.assertTrue(rule_tester(f'{root}/Build'))
-            self.assertFalse(rule_tester(f'{root}/T\\Build'))
+            # Example line in a .gitignore
+            # /Build/
+            self.assertTrue(rule_tester(os.path.join(root, "Build")))
+            self.assertFalse(rule_tester(os.path.join(root, "T", "Build")))
 
-    def test_filter_directory_at_any_level(self):
-        '''
-        Ensure the gitignore parser works properly when a rule specifies that
-        a folder at any depth from the root directory is filtered.
+            # Test a rule which specifies that a folder at any depth from the
+            # root is correclty filtered:
 
-        Example: **/Test/
-        '''
-        with tempfile.TemporaryDirectory() as root:
+            # Example line in a .gitignore
+            # **/Test/
+            self.assertTrue(rule_tester(os.path.join(root, "Test")))
+            self.assertTrue(rule_tester(os.path.join(root, "T", "Test")))
 
-            gitignore_path = BuildGitIgnore(root)
-            rule_tester = gitignore_parser.parse_gitignore_file(gitignore_path)
+            # Test a rule which specifies that a folder containing a specific
+            # string at any depth is correctly filtered:
 
-            # Windows
-            self.assertTrue(rule_tester(f'{root}\\Test'))
-            self.assertTrue(rule_tester(f'{root}\\T\\Test'))
+            # Example line in a .gitignore
+            # *_extdep
+            self.assertTrue(rule_tester(os.path.join(root, 'test_extdep')))
+            self.assertTrue(rule_tester(os.path.join(root, 'T', 'test_extdep')))
 
-            # Linux
-            self.assertTrue(rule_tester(f'{root}/Test'))
-            self.assertTrue(rule_tester(f'{root}/T/Test'))
-
-    def test_filter_specific_folder_name(self):
-        '''
-        Ensure the gitignore parser works properly when a rule specifies that
-        a folder that contains a certain string be filtered
-
-        Example: *_extdep
-        '''
-        with tempfile.TemporaryDirectory() as root:
-
-            gitignore_path = BuildGitIgnore(root)
-            rule_tester = gitignore_parser.parse_gitignore_file(gitignore_path)
-
-            # Windows
-            self.assertTrue(rule_tester(f'{root}\\test_extdep'))
-            self.assertTrue(rule_tester(f'{root}\\T\\test_extdep'))
-
-            # Linux
-            self.assertTrue(rule_tester(f'{root}/test_extdep'))
-            self.assertTrue(rule_tester(f'{root}/T/test_extdep'))
-
-    def test_filter_specific_file_type(self):
-        '''
-        Ensure the gitignore parser works properly when a rule specifies that
-        a file of a specific type  be filtered
-
-        Example: *.DS_Store
-        '''
-        with tempfile.TemporaryDirectory() as root:
-
-            gitignore_path = BuildGitIgnore(root)
-            rule_tester = gitignore_parser.parse_gitignore_file(gitignore_path)
-
-            # Windows
-            self.assertTrue(rule_tester(f'{root}\\file.DS_Store'))
-            self.assertTrue(rule_tester(f'{root}\\T\\file.DS_Store'))
-
-            # Linux
-            self.assertTrue(rule_tester(f'{root}/file.DS_Store'))
-            self.assertTrue(rule_tester(f'{root}/T/file.DS_Store'))
+            # Test a rule which specifies that a file of a specific type at any
+            # depth is correctly filtered:
+            self.assertTrue(rule_tester(os.path.join(root, "file.DS_Store")))
+            self.assertTrue(rule_tester(os.path.join(root, "T", "file.DS_Store")))

--- a/edk2toollib/gitingore_parser_test.py
+++ b/edk2toollib/gitingore_parser_test.py
@@ -90,8 +90,8 @@ class GitIgnoreParserTest(unittest.TestCase):
 
     def test_rule_from_pattern(self):
 
-        # Test to verify basepath must be an absolute path
-        self.assertRaises(ValueError, gitignore_parser.rule_from_pattern, "", "/Test")
+        # Test to bad basepath
+        self.assertRaises(ValueError, gitignore_parser.rule_from_pattern, "", "Test")
 
         # Test ignoring comments, line separators, and incorrect astrick count
         with tempfile.TemporaryDirectory() as root:

--- a/edk2toollib/gitingore_parser_test.py
+++ b/edk2toollib/gitingore_parser_test.py
@@ -17,6 +17,7 @@ def BuildGitIgnore(root):
     path = os.path.join(root, ".gitignore")
     with open(path, "w") as gitignore:
         gitignore.write("/Build/\n")
+        gitignore.write("./Logs/\n")
         gitignore.write("**/Test/\n")
         gitignore.write(".DS_Store\n")
         gitignore.write("*_extdep/\n")
@@ -34,6 +35,7 @@ def BuildGitIgnore(root):
         gitignore.write("/reader/*\n")
         gitignore.write("out?.log\n")
         gitignore.write("log[0-9].txt\n")
+        gitignore.write("log0[!a-z].txt\n")
     return path
 
 
@@ -125,7 +127,10 @@ class GitIgnoreParserTest(unittest.TestCase):
             self.assertFalse(rule_tester(os.path.join(root, 'logF.txt')))
             self.assertFalse(rule_tester(os.path.join(root, 'log11.txt')))
 
-            # logged[!F]
+            # log0[!a-z].txt
+            self.assertTrue(rule_tester(os.path.join(root, 'log01.txt')))
+            self.assertFalse(rule_tester(os.path.join(root, 'log0a.txt')))
+            self.assertTrue(rule_tester(os.path.join(root, 'log0A.txt')))
 
     def test_rule_from_pattern(self):
 

--- a/edk2toollib/gitingore_parser_test.py
+++ b/edk2toollib/gitingore_parser_test.py
@@ -1,0 +1,114 @@
+# @file gitignore_parser.py
+# unit test for gitignore_parser module.
+#
+#
+# Copyright (c) Microsoft Corporation
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+import unittest
+import tempfile
+import edk2toollib.gitignore_parser as gitignore_parser
+import os
+
+
+def BuildGitIgnore(root):
+    path = os.path.join(root, ".gitignore")
+    with open(path, "w") as gitignore:
+        gitignore.write("/Build/\n")
+        gitignore.write("**/Test/\n")
+        gitignore.write(".DS_Store\n")
+        gitignore.write("*_extdep/\n")
+        gitignore.write("*.pyc\n")
+        gitignore.write("__pycache__/\n")
+        gitignore.write("tags/\n")
+        gitignore.write(".vscode/\n")
+        gitignore.write("*.bak\n")
+        gitignore.write("BuildConfig.conf\n")
+        gitignore.write("/BaseTools/BaseToolsBuild/\n")
+        gitignore.write("*.exe")
+    return path
+
+
+class GitIgnoreParserTest(unittest.TestCase):
+
+    def test_filter_directory_at_base(self):
+        '''
+        Ensure the gitignore parser works properly when a rule specifies that
+        a folder at the base of the directory is filtered.
+
+        Example: /Build/
+        '''
+        with tempfile.TemporaryDirectory() as root:
+
+            gitignore_path = BuildGitIgnore(root)
+            rule_tester = gitignore_parser.parse_gitignore_file(gitignore_path)
+
+            # Windows
+            self.assertTrue(rule_tester(f'{root}\\Build'))
+            self.assertFalse(rule_tester(f'{root}\\T\\Build'))
+
+            # Linux
+            self.assertTrue(rule_tester(f'{root}/Build'))
+            self.assertFalse(rule_tester(f'{root}/T\\Build'))
+
+    def test_filter_directory_at_any_level(self):
+        '''
+        Ensure the gitignore parser works properly when a rule specifies that
+        a folder at any depth from the root directory is filtered.
+
+        Example: **/Test/
+        '''
+        with tempfile.TemporaryDirectory() as root:
+
+            gitignore_path = BuildGitIgnore(root)
+            rule_tester = gitignore_parser.parse_gitignore_file(gitignore_path)
+
+            # Windows
+            self.assertTrue(rule_tester(f'{root}\\Test'))
+            self.assertTrue(rule_tester(f'{root}\\T\\Test'))
+
+            # Linux
+            self.assertTrue(rule_tester(f'{root}/Test'))
+            self.assertTrue(rule_tester(f'{root}/T/Test'))
+
+    def test_filter_specific_folder_name(self):
+        '''
+        Ensure the gitignore parser works properly when a rule specifies that
+        a folder that contains a certain string be filtered
+
+        Example: *_extdep
+        '''
+        with tempfile.TemporaryDirectory() as root:
+
+            gitignore_path = BuildGitIgnore(root)
+            rule_tester = gitignore_parser.parse_gitignore_file(gitignore_path)
+
+            # Windows
+            self.assertTrue(rule_tester(f'{root}\\test_extdep'))
+            self.assertTrue(rule_tester(f'{root}\\T\\test_extdep'))
+
+            # Linux
+            self.assertTrue(rule_tester(f'{root}/test_extdep'))
+            self.assertTrue(rule_tester(f'{root}/T/test_extdep'))
+
+    def test_filter_specific_file_type(self):
+        '''
+        Ensure the gitignore parser works properly when a rule specifies that
+        a file of a specific type  be filtered
+
+        Example: *.DS_Store
+        '''
+        with tempfile.TemporaryDirectory() as root:
+
+            gitignore_path = BuildGitIgnore(root)
+            rule_tester = gitignore_parser.parse_gitignore_file(gitignore_path)
+
+            # Windows
+            self.assertTrue(rule_tester(f'{root}\\file.DS_Store'))
+            self.assertTrue(rule_tester(f'{root}\\T\\file.DS_Store'))
+
+            # Linux
+            self.assertTrue(rule_tester(f'{root}/file.DS_Store'))
+            self.assertTrue(rule_tester(f'{root}/T/file.DS_Store'))

--- a/edk2toollib/gitingore_parser_test.py
+++ b/edk2toollib/gitingore_parser_test.py
@@ -1,4 +1,4 @@
-# @file gitignore_parser.py
+# @file gitignore_parser_test.py
 # unit test for gitignore_parser module.
 #
 #
@@ -134,7 +134,7 @@ class GitIgnoreParserTest(unittest.TestCase):
 
     def test_rule_from_pattern(self):
 
-        # Test to bad basepath
+        # Test bad basepath
         self.assertRaises(ValueError, gitignore_parser.rule_from_pattern, "", "Test")
 
         # Test ignoring comments, line separators, and incorrect astrick count


### PR DESCRIPTION
This PR fixes the following:

1. The benign bug for the path separator regex as referenced in #150. The possible separators previously included "|" as a possible delimeter; this has been removed.
2.  A deprecation warning regarding where flags must be located in a regex string. There used to be no requirement, however it is now required that flags are located at the front of the regex string. This changes anchored patterns from being `^(?ms)\<something>` to `(?ms)^\<something>`
3. provides a bugfix where negation rules were not working properly as mentioned in #175 
4. Add test coverage for gitignore_parser