### PR TITLE
Enhance Edk2Path.GetContainingModules() [Rebase & FF]

### DIFF
--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -245,53 +245,99 @@ class Edk2Path(object):
 
         return None
 
-    def GetContainingModules(self, InputPath: str) -> list:
-        """Find the list of modules (infs) that file path is in.
+    def GetContainingModules(self, input_path: str) -> list[str]:
+        """Find the list of modules (inf files) for a file path.
 
-        for now just assume any inf in the same dir or if none
-        then check parent dir.  If InputPath is not in the filesystem
-        this function will try to return the likely containing module
-        but if the entire module has been deleted this isn't possible.
+        Note: This function only accepts absolute paths. An exception will
+              be raised if a non-absolute path is given.
+
+        Note: If input_path does not exist in the filesystem, this function
+              will try to return the likely containing module(s) but if the
+              entire module has been deleted, this isn't possible.
+
+        - If a .inf file is given, that file is returned.
+        - Otherwise, the nearest set of .inf files (in the closest parent)
+          will be returned in a list of file path strings.
 
         Args:
-            InputPath (str): file path in the Os spefic path form
+            input_path (str): Absolute path to a file, directory, or module.
+                              Supports both Windows and Linux like paths.
 
         Returns:
-            (list): list of module inf paths in absolute form.
+            (list[str]): Absolute paths of .inf files that could be the
+                         containing module.
         """
-        self.logger.debug("GetContainingModules: %s" % InputPath)
+        input_path = Path(os.path.normcase(input_path))
+        if not input_path.is_absolute():
+            # Todo: Return a more specific exception type when
+            # https://github.com/tianocore/edk2-pytool-library/issues/184 is
+            # implemented.
+            raise Exception("Module path must be absolute.")
 
-        # if INF return self
-        if fnmatch.fnmatch(InputPath.lower(), '*.inf'):
-            return [InputPath]
+        package_paths = [Path(os.path.normcase(x)) for x in self.PackagePathList]
+        workspace_path = Path(os.path.normcase(self.WorkspacePath))
+        all_root_paths = package_paths + [workspace_path]
 
-        # Before checking the local filesystem for an INF
-        # make sure filesystem has file or at least folder
-        if not os.path.isfile(InputPath):
-            logging.debug("InputPath doesn't exist in filesystem")
+        # For each root path, find the maximum allowed root in its hierarchy.
+        maximum_root_paths = all_root_paths
+        for root_path in maximum_root_paths:
+            for other_root_path in maximum_root_paths[:]:
+                if root_path == other_root_path:
+                    continue
+                if root_path.is_relative_to(other_root_path):
+                    if len(root_path.parts) > len(other_root_path.parts):
+                        maximum_root_paths.remove(root_path)
+                    else:
+                        maximum_root_paths.remove(other_root_path)
+
+        # Verify the file path is within a valid workspace or package path
+        # directory.
+        for path in maximum_root_paths:
+            if input_path.is_relative_to(path):
+                break
+        else:
+            return []
 
         modules = []
-        # Check current dir
-        dirpath = os.path.dirname(InputPath)
-        if os.path.isdir(dirpath):
-            for f in os.listdir(dirpath):
-                if fnmatch.fnmatch(f.lower(), '*.inf'):
-                    self.logger.debug("Found INF file in %s.  INf is: %s", dirpath, f)
-                    modules.append(os.path.join(dirpath, f))
+        if input_path.suffix == '.inf':
+            # Return the file path given since it is a module .inf file
+            modules = [str(input_path)]
 
-        # if didn't find any in current dir go to parent dir.
-        # this handles cases like:
-        # ModuleDir/
-        #   Module.inf
-        #   x64/
-        #     file.c
-        #
-        if (len(modules) == 0):
-            dirpath = os.path.dirname(dirpath)
-            if os.path.isdir(dirpath):
-                for f in os.listdir(dirpath):
-                    if fnmatch.fnmatch(f.lower(), '*.inf'):
-                        self.logger.debug("Found INF file in %s.  INf is: %s", dirpath, f)
-                        modules.append(os.path.join(dirpath, f))
+        if not modules:
+            # Continue to ascend directories up to a maximum root path.
+            #
+            # This handles cases like:
+            #   ModuleDir/      |   ModuleDir/      | ...similarly nested files
+            #     Module.inf    |     Module.inf    |
+            #     x64/          |     Common/       |
+            #       file.c      |       X64/        |
+            #                   |         file.c    |
+            #
+            # The terminating condition of the loop is when a maximum root
+            # path has been reached.
+            #
+            # A maximum root path represents the maximum allowed ascension
+            # point in the input_path directory hierarchy as sub-roots like
+            # a package path pointing under a workspace path are already
+            # accounted for during maximum root path filtering.
+            #
+            # Given a root path is either the workspace or a package path,
+            # neither of which are a module directory, once that point is
+            # reached, all possible module candidates are exhausted.
+            current_dir = input_path.parent
+            while current_dir not in maximum_root_paths:
+                if current_dir.is_dir():
+                    current_dir_inf_files = \
+                        [str(f) for f in current_dir.iterdir() if
+                         f.is_file() and f.suffix.lower() == '.inf']
+                    if current_dir_inf_files:
+                        # A .inf file(s) exist in this directory.
+                        #
+                        # Since this is the closest parent that can be considered
+                        # a module, return the .inf files as module candidates.
+                        modules.extend(current_dir_inf_files)
+                        break
+
+                current_dir = current_dir.parent
 
         return modules

--- a/edk2toollib/uefi/edk2/test_path_utilities.py
+++ b/edk2toollib/uefi/edk2/test_path_utilities.py
@@ -13,6 +13,7 @@ import sys
 import tempfile
 import shutil
 from edk2toollib.uefi.edk2.path_utilities import Edk2Path
+from pathlib import Path
 
 
 class PathUtilitiesTest(unittest.TestCase):
@@ -479,7 +480,9 @@ class PathUtilitiesTest(unittest.TestCase):
         p = os.path.join(ws_pkg_abs, "module1", "testfile.c")
         relist = pathobj.GetContainingModules(p)
         self.assertEqual(len(relist), 1)
-        self.assertIn(os.path.join(ws_pkg_abs, "module1", "module1.inf"), relist)
+        self.assertEqual(
+            Path(os.path.join(ws_pkg_abs, "module1", "module1.inf")),
+            Path(relist[0]))
 
         # file in workspace root - no package- should return ws root
         p = os.path.join(ws_abs, "testfile.c")
@@ -495,13 +498,17 @@ class PathUtilitiesTest(unittest.TestCase):
         p = os.path.join(ws_pkg_abs, "module2", "X64", "testfile.c")
         relist = pathobj.GetContainingModules(p)
         self.assertEqual(len(relist), 1)
-        self.assertIn(os.path.join(ws_pkg_abs, "module2", "module2.inf"), relist)
+        self.assertEqual(
+            Path(os.path.join(ws_pkg_abs, "module2", "module2.inf")),
+            Path(relist[0]))
 
         # inf file in module2 x64
         p = os.path.join(ws_pkg_abs, "module2", "module2.inf")
         relist = pathobj.GetContainingModules(p)
         self.assertEqual(len(relist), 1)
-        self.assertIn(os.path.join(ws_pkg_abs, "module2", "module2.inf"), relist)
+        self.assertEqual(
+            Path(os.path.join(ws_pkg_abs, "module2", "module2.inf")),
+            Path(relist[0]))
 
         # file in PPTestPkg root
         p = os.path.join(pp_pkg_abs, "testfile.c")
@@ -512,13 +519,17 @@ class PathUtilitiesTest(unittest.TestCase):
         p = os.path.join(pp_pkg_abs, "module1", "testfile.c")
         relist = pathobj.GetContainingModules(p)
         self.assertEqual(len(relist), 1)
-        self.assertIn(os.path.join(pp_pkg_abs, "module1", "module1.INF"), relist)
+        self.assertEqual(
+            Path(os.path.join(pp_pkg_abs, "module1", "module1.INF")),
+            Path(relist[0]))
 
         # inf file in module in PPTestPkg
         p = os.path.join(pp_pkg_abs, "module1", "module1.INF")
         relist = pathobj.GetContainingModules(p)
         self.assertEqual(len(relist), 1)
-        self.assertIn(os.path.join(pp_pkg_abs, "module1", "module1.INF"), relist)
+        self.assertEqual(
+            Path(os.path.join(pp_pkg_abs, "module1", "module1.INF")),
+            Path(relist[0]))
 
         # file in packages path root - no module
         p = os.path.join(folder_pp1_abs, "testfile.c")
@@ -540,7 +551,9 @@ class PathUtilitiesTest(unittest.TestCase):
         p = os.path.join(ws_pkg_abs, "module1", "ThisParentDirDoesNotExist", "testfile.c")
         relist = pathobj.GetContainingModules(p)
         self.assertEqual(len(relist), 1)
-        self.assertIn(os.path.join(ws_pkg_abs, "module1", "module1.inf"), relist)
+        self.assertEqual(
+            Path(os.path.join(ws_pkg_abs, "module1", "module1.inf")),
+            Path(relist[0]))
 
     def test_get_edk2_relative_path_from_absolute_path(self):
         ''' test basic usage of GetEdk2RelativePathFromAbsolutePath with packages path nested


### PR DESCRIPTION
This series makes three main changes:

1. [Add test case to show bug in GetContainingModules()](https://github.com/tianocore/edk2-pytool-library/commit/6badaf4581bce1f53445e5899bcb481be0437e66)
   Adds `test_get_containing_module_with_infs_in_other_temp_dirs()` to
   path_utilities_test.py to show that `GetContainingModules()` will
   extend its file search for a .inf file beyond the maximum parent of
   its `Edk2Path` object instance.

   This failure would already reproduce if the user happen to have a
   .inf file in their temporary directory. This test case adds such a
   file to always show this file is returned.

   Further illustrates https://github.com/tianocore/edk2-pytool-library/issues/188

   `GetContainingModules()` will be updated to prevent this behavior in
   a future change.

2. [Verify paths in GetContainingModules() unit tests regardless of format](https://github.com/tianocore/edk2-pytool-library/commit/d6bf93c3f1a9694a67021c6d0794817f0b92bd3b)

   `test_get_containing_module()` performs most of the testing for
   the `Edk2Path.GetContainingModules()` function.

   File paths are checked based on their exact string values rather
   than whether the file path is actually the same.

   This change checks that file paths are expected while accounting
   for differences in path formats.

3. [Enhance GetContainingModules()](https://github.com/tianocore/edk2-pytool-library/commit/d07e7b9e77210a4f793b147ed3d2aab9e86666d4)

   Makes several fixes and improvements to GetContainingModules().

   Fixes #188

   These changes preserve the main behavior of the function while more
   deterministically enforcing requirements and handling additional
   scenarios.

   1. Fixes an issue where the function would look for .inf files in
      directories beyond the maximum allowed directory for the Edk2Path
      object instance.
   
      `test_get_containing_module_with_infs_in_other_temp_dirs()` now
      passes.
   
   2. Explicitly and consistently enforces that absolute paths are
      passed to the function. An exception is raised if a path is not
      absolute. In the past behavior was undefined and not considered
      in the function implementation. A test case is added to confirm
      this behavior.
   
   3. Handles n-levels of nested directories in a module directory as
      opposed to a hardcoded number of 2 (file parent and that parent)
      previously.
   
   4. Verifies the path is within an allowed path for the Edk2Path
      object (the workspace or a valid package path).
   
   5. Returns paths in a consistent and fully resolved format.
   
   6. Improves function documentation.
