### PR TITLE
edk2toollib/uefi/edk2/path_utilities.py: WARNING instead of exception for nested package

### DIFF
--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -75,7 +75,7 @@ class Edk2Path(object):
                 if str(p).lower() == str(ws).lower():
                     break
                 if len(glob.glob(f'{p}/*dec')) != 0:
-                    raise Exception(f'Nested packages not allowed. Pkg path [{package_path}] nested in Package [{p}]')
+                    self.logger.log(logging.WARNING,f'Nested packages not allowed. Pkg path [{package_path}] nested in Package [{p}]')
                 p = p.parent
 
     def GetEdk2RelativePathFromAbsolutePath(self, abspath):

--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -75,7 +75,8 @@ class Edk2Path(object):
                 if str(p).lower() == str(ws).lower():
                     break
                 if len(glob.glob(f'{p}/*dec')) != 0:
-                    self.logger.log(logging.WARNING,f'Nested packages not allowed. Pkg path [{package_path}] nested in Package [{p}]')
+                    self.logger.log(logging.WARNING,
+                                    f'Nested packages not allowed. Pkg path [{package_path}] nested in Package [{p}]')
                 p = p.parent
 
     def GetEdk2RelativePathFromAbsolutePath(self, abspath):

--- a/edk2toollib/uefi/edk2/path_utilities_test.py
+++ b/edk2toollib/uefi/edk2/path_utilities_test.py
@@ -13,6 +13,7 @@ import sys
 import tempfile
 import shutil
 from edk2toollib.uefi.edk2.path_utilities import Edk2Path
+import pytest
 
 
 class PathUtilitiesTest(unittest.TestCase):
@@ -606,6 +607,7 @@ class PathUtilitiesTest(unittest.TestCase):
         p = os.path.join(ws_pkg_abs, "module2", "X64", "TestFile2.c")
         self.assertEqual(pathobj.GetEdk2RelativePathFromAbsolutePath(p), f"{ws_p_name}/module2/X64/TestFile2.c")
 
+    @pytest.mark.skip(reason="disable test until all nested package issues resolved")
     def test_get_relative_path_when_package_path_inside_package(self):
         ''' test usage of GetEdk2RelativePathFromAbsolutePath when a package_path directory is
         inside the subfolders of a package. Should raise an exception.

--- a/edk2toollib/uefi/edk2/path_utilities_test.py
+++ b/edk2toollib/uefi/edk2/path_utilities_test.py
@@ -13,7 +13,6 @@ import sys
 import tempfile
 import shutil
 from edk2toollib.uefi.edk2.path_utilities import Edk2Path
-import pytest
 
 
 class PathUtilitiesTest(unittest.TestCase):
@@ -607,7 +606,6 @@ class PathUtilitiesTest(unittest.TestCase):
         p = os.path.join(ws_pkg_abs, "module2", "X64", "TestFile2.c")
         self.assertEqual(pathobj.GetEdk2RelativePathFromAbsolutePath(p), f"{ws_p_name}/module2/X64/TestFile2.c")
 
-    @pytest.mark.skip(reason="disable test until all nested package issues resolved")
     def test_get_relative_path_when_package_path_inside_package(self):
         ''' test usage of GetEdk2RelativePathFromAbsolutePath when a package_path directory is
         inside the subfolders of a package. Should raise an exception.
@@ -633,7 +631,8 @@ class PathUtilitiesTest(unittest.TestCase):
         folder_pp2_abs = os.path.join(pp1_abs, folder_pp2_rel)
         os.mkdir(folder_pp2_abs)
 
-        self.assertRaises(Exception, Edk2Path, folder_ws_abs, [folder_pp1_abs, folder_pp2_abs])
+#        self.assertRaises(Exception, Edk2Path, folder_ws_abs, [folder_pp1_abs, folder_pp2_abs])
+        Edk2Path(folder_ws_abs, [folder_pp1_abs, folder_pp2_abs])
 
     def test_get_relative_path_when_folder_is_next_to_package(self):
         ''' test usage of GetEdk2RelativePathFromAbsolutePath when a folder containing a package is in the same


### PR DESCRIPTION
Resolves #192 

Update the check for nested packages to generate a WARNING instead of raising an exception.

This check is valuable and all nested packages should be removed. By downgrading this check to a WARNING, the downstream consumers of edk2 can be notified of the issue and be given time to resolve without breaking stuart builds.

Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>