### PR TITLE
Edk2Path: Add an env variable to allow nested packages

### DIFF
--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -100,9 +100,13 @@ class Edk2Path(object):
             package_path_packages[package_path] = \
                 [Path(p).parent for p in package_path.glob('**/*.dec')]
 
+        # Note: The ability to ignore this function raising an exception on
+        #       nested packages is temporary. Do not plan on this variable
+        #       being available long-term and try to resolve the nested
+        #       packages problem right away.
         ignore_nested_packages = False
-        if "STUART_IGNORE_EDK_NESTED_PACKAGES" in os.environ and \
-            os.environ["STUART_IGNORE_EDK_NESTED_PACKAGES"].strip().lower() == \
+        if "PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES" in os.environ and \
+            os.environ["PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES"].strip().lower() == \
                 "true":
             ignore_nested_packages = True
 
@@ -118,11 +122,19 @@ class Edk2Path(object):
                                 f"Nested packages not allowed. The packages "
                                 f"[{str(package)}] and [{str(comp_package)}] are "
                                 f"nested.")
+                            self.logger.log(
+                                logging.WARNING,
+                                "Note 1: Nested packages are being ignored right now because the "
+                                "\"PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES\" environment variable "
+                                "is set. Do not depend on this variable long-term.")
+                            self.logger.log(
+                                logging.WARNING,
+                                "Note 2: Some pytool features may not work as expected with nested packages.")
                         else:
                             raise Exception(
                                 f"Nested packages not allowed. The packages "
                                 f"[{str(package)}] and [{str(comp_package)}] are "
-                                f"nested. Set the \"STUART_IGNORE_EDK_NESTED_PACKAGES\" "
+                                f"nested. Set the \"PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES\" "
                                 f"environment variable to \"true\" as a temporary workaround "
                                 f"until you fix the packages so they are no longer nested.")
 

--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -104,6 +104,9 @@ class Edk2Path(object):
         #       nested packages is temporary. Do not plan on this variable
         #       being available long-term and try to resolve the nested
         #       packages problem right away.
+        #
+        # Removal is tracked in the following GitHub issue:
+        # https://github.com/tianocore/edk2-pytool-library/issues/200
         ignore_nested_packages = False
         if "PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES" in os.environ and \
             os.environ["PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES"].strip().lower() == \

--- a/edk2toollib/uefi/edk2/test_path_utilities.py
+++ b/edk2toollib/uefi/edk2/test_path_utilities.py
@@ -816,7 +816,9 @@ class PathUtilitiesTest(unittest.TestCase):
         self.assertRaises(Exception, Edk2Path, folder_ws_abs, [folder_pp1_abs, folder_pp2_abs])
 
         # Nested packages should no longer raise an exception
-        os.environ["STUART_IGNORE_EDK_NESTED_PACKAGES"] = "true"
+        # Note: These tests can be removed when support for
+        #       PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES is removed.
+        os.environ["PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES"] = "true"
         Edk2Path(folder_ws_abs, [folder_pp1_abs])
         Edk2Path(folder_ws_abs, [folder_pp1_abs, folder_pp2_abs])
 

--- a/edk2toollib/uefi/edk2/test_path_utilities.py
+++ b/edk2toollib/uefi/edk2/test_path_utilities.py
@@ -811,8 +811,14 @@ class PathUtilitiesTest(unittest.TestCase):
         pp2_name = "PPTestPkg2"
         self._make_edk2_package_helper(folder_pp2_abs, pp2_name)
 
+        # Nested packages should raise an exception by default
         self.assertRaises(Exception, Edk2Path, folder_ws_abs, [folder_pp1_abs])
         self.assertRaises(Exception, Edk2Path, folder_ws_abs, [folder_pp1_abs, folder_pp2_abs])
+
+        # Nested packages should no longer raise an exception
+        os.environ["STUART_IGNORE_EDK_NESTED_PACKAGES"] = "true"
+        Edk2Path(folder_ws_abs, [folder_pp1_abs])
+        Edk2Path(folder_ws_abs, [folder_pp1_abs, folder_pp2_abs])
 
     def test_get_relative_path_when_folder_is_next_to_package(self):
         ''' test usage of GetEdk2RelativePathFromAbsolutePath when a folder containing a package is in the same

--- a/edk2toollib/uefi/edk2/test_path_utilities.py
+++ b/edk2toollib/uefi/edk2/test_path_utilities.py
@@ -822,6 +822,9 @@ class PathUtilitiesTest(unittest.TestCase):
         Edk2Path(folder_ws_abs, [folder_pp1_abs])
         Edk2Path(folder_ws_abs, [folder_pp1_abs, folder_pp2_abs])
 
+        # Remove the environment variable now that the test above is complete
+        os.environ.pop("PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES")
+
     def test_get_relative_path_when_folder_is_next_to_package(self):
         ''' test usage of GetEdk2RelativePathFromAbsolutePath when a folder containing a package is in the same
         directory as a different package. This test ensures the correct value is returned regardless the order of


### PR DESCRIPTION
Adds an environment variable called `PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES`
that a platform can set to `"true"` to allow nested packages.

Nested packages are a violation of EDK II package rules and should
be fixed. This is provided for backward compatibility and temporary
use until the variable is no longer needed.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>