### PR TITLE
bug_report.yml: Add supported Python versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -41,11 +41,23 @@ body:
       description: "A clear and concise description of what you expected to happen."
     validations:
       required: true
+  - type: dropdown
+    id: py_version
+    attributes:
+      label: What Python version are you using?
+      description: "Note: Bug fixes are only supported on these Python versions."
+      multiple: true
+      options:
+        - Python 3.9
+        - Python 3.10
+        - Python 3.11
+    validations:
+      required: true
   - type: textarea
     id: env
     attributes:
       label: Execution Environment
-      description: "List the OS, python version, system environment variables, etc."
+      description: "List the OS, python micro version (e.g. 3.10.8), system environment variables, etc."
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
Lists the Python versions supported for bug fixes in the bug reporting form.

This is to make it obvious what Python versions are officially supported for bug fixes when a bug is filed.

Contributes to https://github.com/tianocore/edk2-pytool-library/issues/201

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>