### PR TITLE
path_utilities.py: Prevent path case modification in GetContainingModules()

### DIFF
--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -296,7 +296,7 @@ class Edk2Path(object):
             (list[str]): Absolute paths of .inf files that could be the
                          containing module.
         """
-        input_path = Path(os.path.normcase(input_path))
+        input_path = Path(input_path)
         if not input_path.is_absolute():
             # Todo: Return a more specific exception type when
             # https://github.com/tianocore/edk2-pytool-library/issues/184 is

--- a/edk2toollib/uefi/edk2/test_path_utilities.py
+++ b/edk2toollib/uefi/edk2/test_path_utilities.py
@@ -497,6 +497,70 @@ class PathUtilitiesTest(unittest.TestCase):
             if os.path.isfile(other_inf):
                 os.remove(other_inf)
 
+    def test_get_containing_modules_path_format(self):
+        """Test that get containing modules returns the exact expected path.
+
+        Note: GetContainingModules() only accepts absolute paths.
+
+        File layout:
+            root/                   <-- Current working directory (self.tmp)
+                folder_ws           <-- Workspace directory
+                    pp1             <-- Package Path 1
+                        PPTestPkg   <-- An edk2 package
+                            PPTestPkg.DEC
+                            module1
+                                module1.INF
+                            module2
+                                module2.INF
+                                X64
+                                    TestFile.c
+                    WSTestPkg       <-- An edk2 package
+                        WSTestPkg.dec
+                        module1
+                            module1.inf
+                        module2
+                            module2.inf
+                            X64
+                                TestFile.c
+        """
+        # /folder_ws/
+        ws_rel = "folder_ws"
+        # /folder_ws/pp1/
+        folder_pp_rel = "pp1"
+        # /folder_ws/WSTestPkg/
+        ws_p_name = "WSTestPkg"
+        # /folder_ws/pp1/PPTestPkg
+        pp_p_name = "PPTestPkg"
+
+        # Create <temp_dir>/folder_ws/
+        ws_abs = os.path.join(self.tmp, ws_rel)
+        os.mkdir(ws_abs)
+
+        # Create <temp_dir>/folder_ws/pp1/
+        folder_pp1_abs = os.path.join(ws_abs, folder_pp_rel)
+        os.mkdir(folder_pp1_abs)
+
+        # Create <temp_dir>/folder_ws/WSTestPkg/
+        ws_pkg_abs = self._make_edk2_package_helper(ws_abs, ws_p_name)
+
+        # Create <temp_dir>/folder_ws/pp1/PPTestPkg
+        pp_pkg_abs = self._make_edk2_package_helper(folder_pp1_abs, pp_p_name, extension_case_lower=False)
+        pathobj = Edk2Path(ws_abs, [folder_pp1_abs])
+
+        # Check the case and location of the absolute path
+        p = os.path.join(pp_pkg_abs, "module1", "module1.INF")
+        expected_module_inf = p
+        actual_module_inf_list = pathobj.GetContainingModules(p)
+        self.assertEqual(len(actual_module_inf_list), 1)
+        self.assertEqual(expected_module_inf, actual_module_inf_list[0])
+
+        # Check the case and location of the absolute path
+        p = os.path.join(ws_pkg_abs, "module2", "X64", "TestFile.c")
+        expected_module_inf = os.path.join(ws_pkg_abs, "module2", "module2.inf")
+        actual_module_inf_list = pathobj.GetContainingModules(p)
+        self.assertEqual(len(actual_module_inf_list), 1)
+        self.assertEqual(expected_module_inf, actual_module_inf_list[0])
+
     def test_get_containing_module(self):
         ''' test basic usage of GetContainingModule with packages path nested
         inside the workspace


### PR DESCRIPTION
Closes #204

Updates `Edk2Path.GetContainingModules()` to preserve case the case
for each absolute path returned in the list of absolute paths.

This allows callers dependent on case comparison to get the expected
result.

Also adds a new test case used to verify this change:

- `test_get_containing_modules_path_format()`
   Used to confirm the case in paths returned from
   `Edk2Path.GetContainingModules()`

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>