### PR TITLE
Add GetEdk2RelativePathFromAbsolutePath() POSIX test case

### DIFF
--- a/edk2toollib/uefi/edk2/test_path_utilities.py
+++ b/edk2toollib/uefi/edk2/test_path_utilities.py
@@ -13,7 +13,7 @@ import sys
 import tempfile
 import shutil
 from edk2toollib.uefi.edk2.path_utilities import Edk2Path
-from pathlib import Path
+from pathlib import Path, PurePath
 
 
 class PathUtilitiesTest(unittest.TestCase):
@@ -682,6 +682,64 @@ class PathUtilitiesTest(unittest.TestCase):
         self.assertEqual(
             Path(os.path.join(ws_pkg_abs, "module1", "module1.inf")),
             Path(relist[0]))
+
+    def test_get_edk2_relative_path_from_absolute_path_posix(self):
+        """Test that relative path returned is a POSIX path.
+
+        File layout:
+            root/                   <-- Current working directory (self.tmp)
+                folder_ws           <-- Workspace directory
+                    pp1             <-- Package Path 1
+                        PPTestPkg   <-- An edk2 package
+                            PPTestPkg.DEC
+                            module1
+                                module1.INF
+                            module2
+                                module2.INF
+                                X64
+                                    TestFile.c
+                    WSTestPkg       <-- An edk2 package
+                        WSTestPkg.dec
+                        module1
+                            module1.inf
+                        module2
+                            module2.inf
+                            X64
+                                TestFile.c
+        """
+        # /folder_ws/
+        ws_rel = "folder_ws"
+        # /folder_ws/pp1/
+        folder_pp_rel = "pp1"
+        # /folder_ws/WSTestPkg/
+        ws_p_name = "WSTestPkg"
+        # /folder_ws/pp1/PPTestPkg
+        pp_p_name = "PPTestPkg"
+
+        # Create <temp_dir>/folder_ws/
+        ws_abs = os.path.join(self.tmp, ws_rel)
+        os.mkdir(ws_abs)
+
+        # Create <temp_dir>/folder_ws/pp1/
+        folder_pp1_abs = os.path.join(ws_abs, folder_pp_rel)
+        os.mkdir(folder_pp1_abs)
+
+        # Create <temp_dir>/folder_ws/WSTestPkg/
+        ws_pkg_abs = self._make_edk2_package_helper(ws_abs, ws_p_name)
+
+        # Create <temp_dir>/folder_ws/pp1/PPTestPkg
+        pp_pkg_abs = self._make_edk2_package_helper(folder_pp1_abs, pp_p_name, extension_case_lower=False)
+        pathobj = Edk2Path(ws_abs, [folder_pp1_abs])
+
+        p = os.path.join(pp_pkg_abs, "module1", "module1.INF")
+        expected_rel_from_abs_path = PurePath(os.path.join(pp_p_name, "module1", "module1.INF")).as_posix()
+        actual_rel_from_abs_path = pathobj.GetEdk2RelativePathFromAbsolutePath(p)
+        self.assertEqual(expected_rel_from_abs_path, actual_rel_from_abs_path)
+
+        p = os.path.join(ws_pkg_abs, "module_2", "X64", "TestFile.inf")
+        expected_rel_from_abs_path = PurePath(os.path.join(ws_p_name, "module_2", "X64", "TestFile.inf")).as_posix()
+        actual_rel_from_abs_path = pathobj.GetEdk2RelativePathFromAbsolutePath(p)
+        self.assertEqual(expected_rel_from_abs_path, actual_rel_from_abs_path)
 
     def test_get_edk2_relative_path_from_absolute_path(self):
         ''' test basic usage of GetEdk2RelativePathFromAbsolutePath with packages path nested


### PR DESCRIPTION
Adds a test case to verify the function returns POSIX paths as expected.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>