### PR TITLE
Update vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,9 +2,9 @@
   "python.testing.unittestArgs": [
     "-v",
     "-s",
-    "${workspaceRoot}/edk2toollib",
+    "${workspaceRoot}/edk2toollib/tests",
     "-p",
-    "*_test.py"
+    "test_*.py"
   ],
   "python.testing.pytestEnabled": false,
   "python.testing.unittestEnabled": true,


### PR DESCRIPTION
With test naming standard and location changed, vscode settings file needs updated so that the testing extension works properly.

Signed-off-by: Joey Vagedes <joeyvagedes@microsoft.com>