### PR TITLE
Add support for ignoring known-bad packages

### DIFF
--- a/edk2toollib/tests/test_path_utilities.py
+++ b/edk2toollib/tests/test_path_utilities.py
@@ -947,6 +947,23 @@ class PathUtilitiesTest(unittest.TestCase):
         # Remove the environment variable now that the test above is complete
         os.environ.pop("PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES")
 
+        # Nested packages should no longer raise an exception if explicitly
+        # marked as known-bad.
+        os.environ["PYTOOL_IGNORE_KNOWN_BAD_NESTED_PACKAGES"] = "SomeOtherPkg,PPTestPkg1"
+        Edk2Path(folder_ws_abs, [folder_pp1_abs])
+        Edk2Path(folder_ws_abs, [folder_pp1_abs, folder_pp2_abs])
+
+        os.environ["PYTOOL_IGNORE_KNOWN_BAD_NESTED_PACKAGES"] = "SomeOtherPkg,PPTestPkg2"
+        Edk2Path(folder_ws_abs, [folder_pp1_abs])
+        Edk2Path(folder_ws_abs, [folder_pp1_abs, folder_pp2_abs])
+
+        os.environ["PYTOOL_IGNORE_KNOWN_BAD_NESTED_PACKAGES"] = "SomeOtherPkg,SomeOtherPkg2"
+        self.assertRaises(Exception, Edk2Path, folder_ws_abs, [folder_pp1_abs])
+        self.assertRaises(Exception, Edk2Path, folder_ws_abs, [folder_pp1_abs, folder_pp2_abs])
+
+        # Remove the environment variable now that the test above is complete
+        os.environ.pop("PYTOOL_IGNORE_KNOWN_BAD_NESTED_PACKAGES")
+
     def test_get_relative_path_when_folder_is_next_to_package(self):
         ''' test usage of GetEdk2RelativePathFromAbsolutePath when a folder containing a package is in the same
         directory as a different package. This test ensures the correct value is returned regardless the order of

--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -18,6 +18,16 @@ class Edk2Path(object):
     """Represents edk2 file paths.
 
     Class that helps perform path operations within an EDK workspace.
+
+    There are two OS environment variables that modify the behavior of this class with
+    respect to nested package checking:
+        PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES - converts errors about nested
+            packages to warnings.
+        PYTOOL_IGNORE_KNOWN_BAD_NESTED_PACKAGES - contains a comma-delimited list of
+            known bad packages. If a package matching a known bad package from the
+            list is encountered, an info-level message will be printed and the nested
+            package check will be skipped.
+
     """
 
     def __init__(self, ws: os.PathLike, package_path_list: Iterable[os.PathLike],

--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -113,8 +113,22 @@ class Edk2Path(object):
                 "true":
             ignore_nested_packages = True
 
+        if "PYTOOL_IGNORE_KNOWN_BAD_NESTED_PACKAGES" in os.environ:
+            pkgs_to_ignore = os.environ["PYTOOL_IGNORE_KNOWN_BAD_NESTED_PACKAGES"].split(",")
+        else:
+            pkgs_to_ignore = []
+
         for package_path, packages in package_path_packages.items():
-            for i, package in enumerate(packages):
+            packages_to_check = []
+            for package in packages:
+                if any(x in str(package) for x in pkgs_to_ignore):
+                    self.logger.log(
+                        logging.INFO,
+                        f"Ignoring nested package check for known-bad package "
+                        f"[{str(package)}].")
+                else:
+                    packages_to_check.append(package)
+            for i, package in enumerate(packages_to_check):
                 for j in range(i + 1, len(packages)):
                     comp_package = packages[j]
                     if (package.is_relative_to(comp_package)

--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -129,8 +129,8 @@ class Edk2Path(object):
                 else:
                     packages_to_check.append(package)
             for i, package in enumerate(packages_to_check):
-                for j in range(i + 1, len(packages)):
-                    comp_package = packages[j]
+                for j in range(i + 1, len(packages_to_check)):
+                    comp_package = packages_to_check[j]
                     if (package.is_relative_to(comp_package)
                             or comp_package.is_relative_to(package)):
                         if ignore_nested_packages:


### PR DESCRIPTION
This adds an environment variable to allow the nested package check to be demoted to an INFO-level log for packages that are known to be bad and cannot be immediately remediated. This avoids a large number of warning messages that would otherwise make it more likely for developers to ignore warnings entirely.