### PR TITLE
utility_functions: Force GetHostInfo() to return MacOs

### DIFF
--- a/edk2toollib/utility_functions.py
+++ b/edk2toollib/utility_functions.py
@@ -100,6 +100,11 @@ def GetHostInfo():
     arch = None
     bit = None
 
+    # For backwards compatibility, platform.uname() returns Darwin for macs, which is the kernal rather then the OS.
+    # Due to this, we manually fix it.
+    if os == "Darwin":
+        os = "MacOs"
+
     if ("x86" in processor_info.lower()) or ("AMD" in processor_info.upper()) or ("INTEL" in processor_info.upper()):
         arch = "x86"
     elif ("ARM" in processor_info.upper()) or ("AARCH" in processor_info.upper()):


### PR DESCRIPTION
platform.uname() returns Darwin instead of MacOs due to backwards compatibility. Force GetHostInfo() to return MacOs rather than Darwin as darwin is the kernal, not the OS.