### PR TITLE
Update vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,9 @@
 {
-  "python.testing.unittestArgs": [
-    "-v",
-    "-s",
+  "python.testing.pytestEnabled": true,
+  "python.testing.pytestArgs": [
     "${workspaceRoot}/edk2toollib/tests",
-    "-p",
-    "test_*.py"
   ],
-  "python.testing.pytestEnabled": false,
-  "python.testing.unittestEnabled": true,
+  "python.testing.unittestEnabled": false,
   "python.linting.flake8Enabled": true,
   "python.linting.enabled": true,
   "python.linting.pydocstyleEnabled": true


### PR DESCRIPTION
Transitions vscode default test settings to pytest rather then unittests to match what is done for CI via github actions.