### PR TITLE
utility_functions.py - bugfix encoding when locale information missing

### DIFF
--- a/edk2toollib/utility_functions.py
+++ b/edk2toollib/utility_functions.py
@@ -71,7 +71,7 @@ def reader(filepath, outstream, stream, logging_level=logging.INFO, encodingErro
 
     (_, encoding) = locale.getdefaultlocale()
     while True:
-        s = stream.readline().decode(encoding, errors=encodingErrors)
+        s = stream.readline().decode(encoding or 'utf-8', errors=encodingErrors)
         if not s:
             break
         if (f is not None):


### PR DESCRIPTION
If locality information is missing on the system, `locale.getdefaultlocale()` fails to return a valid encoding and thus any `RunCmd()` call will fail. This adds in the logic to default to utf-8 if locality information returns None for the encoding.