### PR TITLE
locate_tools: set comparison invalid due to mismatched case of keys

### DIFF
--- a/edk2toollib/windows/locate_tools.py
+++ b/edk2toollib/windows/locate_tools.py
@@ -227,7 +227,7 @@ def QueryVcVariables(keys: list, arch: str = None, product: str = None, vs_versi
     if len(result) != len(interesting):
         logging.debug("Input: " + str(sorted(interesting)))
         logging.debug("Result: " + str(sorted(list(result.keys()))))
-        result_set = set(list(result.keys()))
+        result_set = set([key.upper() for key in result.keys()])
         difference = list(interesting.difference(result_set))
 
         logging.error("We were not able to find on the keys requested from vcvarsall.")


### PR DESCRIPTION
Within `QueryVcVariables()`, A set comparison is made between the requested variables and the returned variables to determine (and raise an error printing) the missing keys. There is a difference in case for the two sets, one being all uppsercase values while the other is not. This change updates both sets to contain all uppercase values.

Reported by @LethargicHitman in #297