### PR TITLE
path_utilities.py: update Edk2Path documentation

### DIFF
--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -19,6 +19,12 @@ class Edk2Path(object):
 
     Class that helps perform path operations within an EDK workspace.
 
+    !!! warning
+        Edk2Path performs expensive packages path and package validation when
+        instantiated. If using the same Workspace root and packages path, it is
+        suggested that only a single Edk2Path instance is instantiated and
+        passed to any consumers.
+
     There are two OS environment variables that modify the behavior of this class with
     respect to nested package checking:
         PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES - converts errors about nested


### PR DESCRIPTION
Updates Edk2Path documentation to inform users that Edk2Path instantiation is an expensive operation due to packages path and package validation, so it should be instantiated as few times as possible. Requested via #288