### PR TITLE
inf_generator: update DefaultDestDir

### DIFF
--- a/edk2toollib/windows/capsule/inf_generator.py
+++ b/edk2toollib/windows/capsule/inf_generator.py
@@ -300,7 +300,7 @@ HKLM,SYSTEM\CurrentControlSet\Control\FirmwareResources\{{{EsrtGuid}}},Policy,%R
         add_reg.Items.append("HKR,,FirmwareId,,{{{guid}}}".format(guid=self.EsrtGuid))
         add_reg.Items.append("HKR,,FirmwareVersion,%REG_DWORD%,{version}".format(
             version=self.VersionHex))
-        add_reg.Items.append("HKR,,FirmwareFilename,,{file_name}".format(file_name=binfilename))
+        add_reg.Items.append("HKR,,FirmwareFilename,,%13%\\{file_name}".format(file_name=binfilename))
 
         disks_files = InfSection('SourceDisksFiles')
         disks_files.Items.append("{file_name} = 1".format(file_name=binfilename))

--- a/edk2toollib/windows/capsule/inf_generator.py
+++ b/edk2toollib/windows/capsule/inf_generator.py
@@ -72,7 +72,7 @@ AddReg = Firmware_AddReg
 {SourceDisksFilesSection}
 
 [DestinationDirs]
-DefaultDestDir = %DIRID_WINDOWS%,Firmware ; %SystemRoot%\Firmware
+DefaultDestDir = 13
 
 [Strings]
 ; localizable

--- a/edk2toollib/windows/capsule/inf_generator2.py
+++ b/edk2toollib/windows/capsule/inf_generator2.py
@@ -331,7 +331,7 @@ class InfSourceFiles(object):
         outstr += Files
         outstr += textwrap.dedent("""
             [DestinationDirs]
-            DefaultDestDir = %DIRID_WINDOWS%,Firmware ; %SystemRoot%\\Firmware
+            DefaultDestDir = 13
 
             """)
         return outstr

--- a/edk2toollib/windows/capsule/inf_generator2.py
+++ b/edk2toollib/windows/capsule/inf_generator2.py
@@ -237,7 +237,7 @@ class InfFirmware(object):
             [{self.Tag}_AddReg]
             HKR,,FirmwareId,,{{{self.EsrtGuid}}}
             HKR,,FirmwareVersion,%REG_DWORD%,0x{self.VersionInt:X}
-            HKR,,FirmwareFilename,,{self.FirmwareFile}
+            HKR,,FirmwareFilename,,%13%\\{self.FirmwareFile}
             """)
         outstr += IntegrityFileReg + "\n"
         return outstr

--- a/tests.unit/test_inf_generator.py
+++ b/tests.unit/test_inf_generator.py
@@ -168,7 +168,7 @@ AddReg = Firmware_AddReg
 [Firmware_AddReg]
 HKR,,FirmwareId,,{3cad7a0c-d35b-4b75-96b1-03a9fb07b7fc}
 HKR,,FirmwareVersion,%REG_DWORD%,0x1020304
-HKR,,FirmwareFilename,,TestFirmwareRom.bin
+HKR,,FirmwareFilename,,%13%\\TestFirmwareRom.bin
 
 [SourceDisksNames]
 1 = %DiskName%

--- a/tests.unit/test_inf_generator.py
+++ b/tests.unit/test_inf_generator.py
@@ -177,7 +177,7 @@ HKR,,FirmwareFilename,,TestFirmwareRom.bin
 TestFirmwareRom.bin = 1
 
 [DestinationDirs]
-DefaultDestDir = %DIRID_WINDOWS%,Firmware ; %SystemRoot%\\Firmware
+DefaultDestDir = 13
 
 [Strings]
 ; localizable

--- a/tests.unit/test_inf_generator2.py
+++ b/tests.unit/test_inf_generator2.py
@@ -522,7 +522,7 @@ class InfFileTest(unittest.TestCase):
             test2.bin = 1
 
             [DestinationDirs]
-            DefaultDestDir = %DIRID_WINDOWS%,Firmware ; %SystemRoot%\\Firmware
+            DefaultDestDir = 13
 
             [Strings]
             ; localizable
@@ -734,7 +734,7 @@ class InfFileTest(unittest.TestCase):
             integrity2.bin = 1
 
             [DestinationDirs]
-            DefaultDestDir = %DIRID_WINDOWS%,Firmware ; %SystemRoot%\\Firmware
+            DefaultDestDir = 13
 
             [Strings]
             ; localizable

--- a/tests.unit/test_inf_generator2.py
+++ b/tests.unit/test_inf_generator2.py
@@ -91,7 +91,7 @@ class InfFirmwareTest(unittest.TestCase):
             [tag_AddReg]
             HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
-            HKR,,FirmwareFilename,,test.bin
+            HKR,,FirmwareFilename,,%13%\\test.bin
 
             """)
 
@@ -132,7 +132,7 @@ class InfFirmwareTest(unittest.TestCase):
             [tag_AddReg]
             HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
-            HKR,,FirmwareFilename,,test.bin
+            HKR,,FirmwareFilename,,%13%\\test.bin
 
             """)
 
@@ -175,7 +175,7 @@ class InfFirmwareTest(unittest.TestCase):
             [tag_AddReg]
             HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
-            HKR,,FirmwareFilename,,test.bin
+            HKR,,FirmwareFilename,,%13%\\test.bin
             HKR,,FirmwareIntegrityFilename,,test2.bin
 
             """)
@@ -273,7 +273,7 @@ class InfFirmwareSectionsTest(unittest.TestCase):
             [tag_AddReg]
             HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
-            HKR,,FirmwareFilename,,test.bin
+            HKR,,FirmwareFilename,,%13%\\test.bin
 
             """)
 
@@ -328,7 +328,7 @@ class InfFirmwareSectionsTest(unittest.TestCase):
             [tag1_AddReg]
             HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
-            HKR,,FirmwareFilename,,test1.bin
+            HKR,,FirmwareFilename,,%13%\\test1.bin
 
             [tag2_Install.NT]
             CopyFiles = tag2_CopyFiles
@@ -342,7 +342,7 @@ class InfFirmwareSectionsTest(unittest.TestCase):
             [tag2_AddReg]
             HKR,,FirmwareId,,{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000002
-            HKR,,FirmwareFilename,,test2.bin
+            HKR,,FirmwareFilename,,%13%\\test2.bin
 
             """)
 
@@ -498,7 +498,7 @@ class InfFileTest(unittest.TestCase):
             [tag1_AddReg]
             HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
-            HKR,,FirmwareFilename,,test1.bin
+            HKR,,FirmwareFilename,,%13%\\test1.bin
 
             [tag2_Install.NT]
             CopyFiles = tag2_CopyFiles
@@ -512,7 +512,7 @@ class InfFileTest(unittest.TestCase):
             [tag2_AddReg]
             HKR,,FirmwareId,,{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000002
-            HKR,,FirmwareFilename,,test2.bin
+            HKR,,FirmwareFilename,,%13%\\test2.bin
 
             [SourceDisksNames]
             1 = %DiskName%
@@ -596,7 +596,7 @@ class InfFileTest(unittest.TestCase):
             [tag1_AddReg]
             HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
-            HKR,,FirmwareFilename,,test1.bin
+            HKR,,FirmwareFilename,,%13%\\test1.bin
 
             [tag2_Install.NT]
             CopyFiles = tag2_CopyFiles
@@ -614,7 +614,7 @@ class InfFileTest(unittest.TestCase):
             [tag2_AddReg]
             HKR,,FirmwareId,,{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000002
-            HKR,,FirmwareFilename,,test2.bin
+            HKR,,FirmwareFilename,,%13%\\test2.bin
 
             [SourceDisksNames]
             1 = %DiskName%
@@ -701,7 +701,7 @@ class InfFileTest(unittest.TestCase):
             [tag1_AddReg]
             HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
-            HKR,,FirmwareFilename,,test1.bin
+            HKR,,FirmwareFilename,,%13%\\test1.bin
             HKR,,FirmwareIntegrityFilename,,integrity1.bin
 
             [tag2_Install.NT]
@@ -721,7 +721,7 @@ class InfFileTest(unittest.TestCase):
             [tag2_AddReg]
             HKR,,FirmwareId,,{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000002
-            HKR,,FirmwareFilename,,test2.bin
+            HKR,,FirmwareFilename,,%13%\\test2.bin
             HKR,,FirmwareIntegrityFilename,,integrity2.bin
 
             [SourceDisksNames]

--- a/tests.unit/test_inf_generator2.py
+++ b/tests.unit/test_inf_generator2.py
@@ -624,7 +624,7 @@ class InfFileTest(unittest.TestCase):
             test2.bin = 1
 
             [DestinationDirs]
-            DefaultDestDir = %DIRID_WINDOWS%,Firmware ; %SystemRoot%\\Firmware
+            DefaultDestDir = 13
 
             [Strings]
             ; localizable

--- a/tests.unit/test_inf_generator2.py
+++ b/tests.unit/test_inf_generator2.py
@@ -382,7 +382,7 @@ class InfSourceFilesTest(unittest.TestCase):
             test3.bin = 1
 
             [DestinationDirs]
-            DefaultDestDir = %DIRID_WINDOWS%,Firmware ; %SystemRoot%\\Firmware
+            DefaultDestDir = 13
 
             """)
 


### PR DESCRIPTION
The required DefaultDestDir was changed from `%DIRID_WINDOWS%,Firmware\{6bd4efb9-23cc-4b4a-ac37-016517413e9a}` to `13` with the release of Windows 10 1803 but was never updated in either inf_generator.py or inf_generator2.py. As Windows 10 1803 has been EOL since November 12, 2019,  I see no reason to support the previous requirements and will transition to the new value.

Thanks @joschock for bringing this to light in #291