### PR TITLE
Capsule install fix for the inf_generators.

### DIFF
--- a/edk2toollib/windows/capsule/inf_generator.py
+++ b/edk2toollib/windows/capsule/inf_generator.py
@@ -307,7 +307,7 @@ HKLM,SYSTEM\CurrentControlSet\Control\FirmwareResources\{{{EsrtGuid}}},Policy,%R
 
         if self.IntegrityFilename != "":
             copy_files.Items.append(self.IntegrityFilename)
-            add_reg.Items.append("HKR,,FirmwareIntegrityFilename,,{file_name}".format(file_name=self.IntegrityFilename))
+            add_reg.Items.append("HKR,,FirmwareIntegrityFilename,,%13%\\{file_name}".format(file_name=self.IntegrityFilename))
             disks_files.Items.append("{file_name} = 1".format(file_name=self.IntegrityFilename))
 
         Content = InfGenerator.TEMPLATE.format(

--- a/edk2toollib/windows/capsule/inf_generator2.py
+++ b/edk2toollib/windows/capsule/inf_generator2.py
@@ -215,7 +215,7 @@ class InfFirmware(object):
         # build integrity file string, if required.
         if (self.IntegrityFile is not None):
             IntegrityFile = f"{self.IntegrityFile}\n"
-            IntegrityFileReg = f"HKR,,FirmwareIntegrityFilename,,{self.IntegrityFile}\n"
+            IntegrityFileReg = f"HKR,,FirmwareIntegrityFilename,,%13%\\{self.IntegrityFile}\n"
         else:
             IntegrityFile = ""
             IntegrityFileReg = ""

--- a/tests.unit/test_inf_generator2.py
+++ b/tests.unit/test_inf_generator2.py
@@ -176,7 +176,7 @@ class InfFirmwareTest(unittest.TestCase):
             HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
             HKR,,FirmwareFilename,,%13%\\test.bin
-            HKR,,FirmwareIntegrityFilename,,test2.bin
+            HKR,,FirmwareIntegrityFilename,,%13%\\test2.bin
 
             """)
 
@@ -702,7 +702,7 @@ class InfFileTest(unittest.TestCase):
             HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
             HKR,,FirmwareFilename,,%13%\\test1.bin
-            HKR,,FirmwareIntegrityFilename,,integrity1.bin
+            HKR,,FirmwareIntegrityFilename,,%13%\\integrity1.bin
 
             [tag2_Install.NT]
             CopyFiles = tag2_CopyFiles
@@ -722,7 +722,7 @@ class InfFileTest(unittest.TestCase):
             HKR,,FirmwareId,,{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000002
             HKR,,FirmwareFilename,,%13%\\test2.bin
-            HKR,,FirmwareIntegrityFilename,,integrity2.bin
+            HKR,,FirmwareIntegrityFilename,,%13%\\integrity2.bin
 
             [SourceDisksNames]
             1 = %DiskName%


### PR DESCRIPTION
[Pr #315 ](https://github.com/tianocore/edk2-pytool-library/pull/315) Introduced a bug with capsule update from the OS where the capsule update fails and shows up as _error: missing file %hs_.  This fixes that bug by correctly putting the FirmwareIntegrityFilename into the new directory with FirmwareFilename.

Fixes [Issue #351](https://github.com/tianocore/edk2-pytool-library/issues/351)

Tested on Intel physical platforms.