### PR TITLE
dec_parser: support parsing pcd strings with pipes

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/dec_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/dec_parser.py
@@ -7,6 +7,7 @@
 ##
 """Code to help parse DEC files."""
 import os
+import re
 
 from edk2toollib.uefi.edk2.parsers.base_parser import HashFileParser
 from edk2toollib.uefi.edk2.parsers.guid_parser import GuidParser
@@ -123,7 +124,11 @@ class PcdDeclarationEntry():
         """Parses the PcdDeclaration Entry for one PCD."""
         sp = rawtext.partition(".")
         self.token_space_name = sp[0].strip()
-        op = sp[2].split("|")
+
+        # Regular expression pattern to match the symbol '|' that is not inside quotes
+        pattern = r'\|(?=(?:[^\'"]*[\'"][^\'"]*[\'"])*[^\'"]*$)'
+        op = re.split(pattern, sp[2])
+
         # if it's 2 long, we need to check that it's a structured PCD
         if (len(op) == 2 and op[0].count(".") > 0):
             pass

--- a/tests.unit/parsers/test_dec_parser.py
+++ b/tests.unit/parsers/test_dec_parser.py
@@ -7,15 +7,18 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 
+import io
 import unittest
 import uuid
-import io
-from edk2toollib.uefi.edk2.parsers.dec_parser import LibraryClassDeclarationEntry
-from edk2toollib.uefi.edk2.parsers.dec_parser import GuidDeclarationEntry
-from edk2toollib.uefi.edk2.parsers.dec_parser import PpiDeclarationEntry
-from edk2toollib.uefi.edk2.parsers.dec_parser import ProtocolDeclarationEntry
-from edk2toollib.uefi.edk2.parsers.dec_parser import PcdDeclarationEntry
-from edk2toollib.uefi.edk2.parsers.dec_parser import DecParser
+
+from edk2toollib.uefi.edk2.parsers.dec_parser import (
+    DecParser,
+    GuidDeclarationEntry,
+    LibraryClassDeclarationEntry,
+    PcdDeclarationEntry,
+    PpiDeclarationEntry,
+    ProtocolDeclarationEntry,
+)
 
 
 class TestGuidDeclarationEntry(unittest.TestCase):
@@ -107,6 +110,22 @@ class TestPcdDeclarationEntry(unittest.TestCase):
         with self.assertRaises(Exception):
             PcdDeclarationEntry("testpkg", SAMPLE_DATA_DECL)
 
+    def test_string_containing_a_pipe(self):
+        SAMPLE_DATA_DECL = """gTestTokenSpaceGuid.PcdTestString | L"TestVal_1 | TestVal_2" | VOID* | 0x00010001"""
+        a = PcdDeclarationEntry("testpkg", SAMPLE_DATA_DECL)
+        self.assertEqual(a.token_space_name, "gTestTokenSpaceGuid")
+        self.assertEqual(a.name, "PcdTestString")
+        self.assertEqual(a.default_value, "L\"TestVal_1 | TestVal_2\"")
+        self.assertEqual(a.type, "VOID*")
+        self.assertEqual(a.id, "0x00010001")
+
+        SAMPLE_DATA_DECL = """gTestTokenSpaceGuid.PcdTestString | L'TestVal_1 | TestVal_2' | VOID* | 0x00010001"""
+        a = PcdDeclarationEntry("testpkg", SAMPLE_DATA_DECL)
+        self.assertEqual(a.token_space_name, "gTestTokenSpaceGuid")
+        self.assertEqual(a.name, "PcdTestString")
+        self.assertEqual(a.default_value, "L'TestVal_1 | TestVal_2'")
+        self.assertEqual(a.type, "VOID*")
+        self.assertEqual(a.id, "0x00010001")
 
 class TestDecParser(unittest.TestCase):
 


### PR DESCRIPTION
previously, the dec parser would fail to parse a PcdDeclarationEntry that contained a pipe symbol in the default value. This commit updates the parser to detect pipes wrapped in quotes and not split on it.

closes #234 