### PR TITLE
utility_functions: reader: use stdout encoding

### DIFF
--- a/edk2toollib/utility_functions.py
+++ b/edk2toollib/utility_functions.py
@@ -10,7 +10,6 @@
 import datetime
 import importlib
 import inspect
-import locale
 import logging
 import os
 import platform
@@ -70,9 +69,8 @@ def reader(filepath, outstream, stream, logging_level=logging.INFO, encodingErro
     if (filepath):
         f = open(filepath, "w")
 
-    (_, encoding) = locale.getdefaultlocale()
     while True:
-        s = stream.readline().decode(encoding or 'utf-8', errors=encodingErrors)
+        s = stream.readline().decode(sys.stdout.encoding)
         if not s:
             break
         if (f is not None):

--- a/edk2toollib/utility_functions.py
+++ b/edk2toollib/utility_functions.py
@@ -70,7 +70,7 @@ def reader(filepath, outstream, stream, logging_level=logging.INFO, encodingErro
         f = open(filepath, "w")
 
     while True:
-        s = stream.readline().decode(sys.stdout.encoding, errors=encodingErrors)
+        s = stream.readline().decode(sys.stdout.encoding or 'utf-8', errors=encodingErrors)
         if not s:
             break
         if (f is not None):

--- a/edk2toollib/utility_functions.py
+++ b/edk2toollib/utility_functions.py
@@ -70,7 +70,7 @@ def reader(filepath, outstream, stream, logging_level=logging.INFO, encodingErro
         f = open(filepath, "w")
 
     while True:
-        s = stream.readline().decode(sys.stdout.encoding)
+        s = stream.readline().decode(sys.stdout.encoding, errors=encodingErrors)
         if not s:
             break
         if (f is not None):


### PR DESCRIPTION
the reader() function, used to parse the output of a subprocess would decode using a different standard as specified by
locale.getdefaultlocale(), which was deprecated. This commit changes the decode format to be sys.stdout.encoding, which is more accurate than locale.getdefaultlocale() as it is the actual encoding of stdout, which is what the reader function is decoding

Cannot tag @kuqin12, so doing it here.

closes #216 