### PR TITLE
ansi_handler: support all string representable objects in LogRecord message

### DIFF
--- a/edk2toollib/log/ansi_handler.py
+++ b/edk2toollib/log/ansi_handler.py
@@ -203,7 +203,7 @@ class ColoredFormatter(logging.Formatter):
     def format(self, record):
         """Formats the given record and returns it."""
         levelname = record.levelname
-        message = record.getMessage()
+        org_message = record.msg
 
         if not self.use_azure and levelname in ColoredFormatter.COLORS:
             # just color the level name
@@ -212,7 +212,7 @@ class ColoredFormatter(logging.Formatter):
             # otherwise color the wholes message
             else:
                 levelname_color = get_ansi_string(ColoredFormatter.COLORS[levelname]) + levelname
-                message += get_ansi_string()
+                record.msg = str(org_message) + get_ansi_string()
             record.levelname = levelname_color
 
         if self.use_azure and levelname in ColoredFormatter.AZURE_COLORS:
@@ -223,7 +223,8 @@ class ColoredFormatter(logging.Formatter):
         result = logging.Formatter.format(self, record)
 
         record.levelname = levelname
-        record.msg = message
+        record.msg = org_message
+
         return result
 
 

--- a/edk2toollib/log/ansi_handler.py
+++ b/edk2toollib/log/ansi_handler.py
@@ -203,7 +203,7 @@ class ColoredFormatter(logging.Formatter):
     def format(self, record):
         """Formats the given record and returns it."""
         levelname = record.levelname
-        org_message = record.msg
+        message = record.getMessage()
 
         if not self.use_azure and levelname in ColoredFormatter.COLORS:
             # just color the level name
@@ -212,7 +212,7 @@ class ColoredFormatter(logging.Formatter):
             # otherwise color the wholes message
             else:
                 levelname_color = get_ansi_string(ColoredFormatter.COLORS[levelname]) + levelname
-                record.msg += get_ansi_string()
+                message += get_ansi_string()
             record.levelname = levelname_color
 
         if self.use_azure and levelname in ColoredFormatter.AZURE_COLORS:
@@ -223,7 +223,7 @@ class ColoredFormatter(logging.Formatter):
         result = logging.Formatter.format(self, record)
 
         record.levelname = levelname
-        record.msg = org_message
+        record.msg = message
         return result
 
 
@@ -440,5 +440,6 @@ class ColoredStreamHandler(logging.StreamHandler):
             self.write(str(msg))
             self.write(self.terminator)
             self.flush()
-        except Exception:
+        except Exception as e:
+            print(e)
             self.handleError(record)

--- a/edk2toollib/log/ansi_handler.py
+++ b/edk2toollib/log/ansi_handler.py
@@ -224,7 +224,6 @@ class ColoredFormatter(logging.Formatter):
 
         record.levelname = levelname
         record.msg = org_message
-
         return result
 
 
@@ -441,6 +440,5 @@ class ColoredStreamHandler(logging.StreamHandler):
             self.write(str(msg))
             self.write(self.terminator)
             self.flush()
-        except Exception as e:
-            print(e)
+        except Exception:
             self.handleError(record)

--- a/tests.unit/test_ansi_handler.py
+++ b/tests.unit/test_ansi_handler.py
@@ -34,7 +34,7 @@ class AnsiHandlerTest(unittest.TestCase):
                                      "msg": ('Logging', 'A', 'Tuple')})
     record5 = logging.makeLogRecord({"name": "", "level": logging.ERROR, "levelno": logging.ERROR,
                                      "levelname": "ERROR", "path": "test_path", "lineno": 0,
-                                     "msg": iter(('Logging', 'A', 'Iter'))})
+                                     "msg": "Testing This Works: %s", "args": ("Test",)})
 
     def test_colored_formatter_init(self):
         formatter = ColoredFormatter("%(levelname)s - %(message)s")
@@ -100,6 +100,7 @@ class AnsiHandlerTest(unittest.TestCase):
         handler.setFormatter(formatter)
         handler.setLevel(logging.INFO)
 
+        handler.emit(AnsiHandlerTest.record5)
         handler.emit(AnsiHandlerTest.record3)
         handler.emit(AnsiHandlerTest.record4)
         handler.emit(AnsiHandlerTest.record5)
@@ -107,6 +108,7 @@ class AnsiHandlerTest(unittest.TestCase):
 
         stream.seek(0)
         lines = stream.readlines()
-        CSI = '\033[31m'
+        CSI = '\033[31m' # Red
+        CSI2 = '\033[39m' # Reset
         for line in lines:
-            assert CSI in line
+            assert CSI in line and CSI2 in line

--- a/tests.unit/test_ansi_handler.py
+++ b/tests.unit/test_ansi_handler.py
@@ -5,10 +5,10 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
-import unittest
 import logging
-from edk2toollib.log.ansi_handler import ColoredFormatter
-from edk2toollib.log.ansi_handler import ColoredStreamHandler
+import unittest
+
+from edk2toollib.log.ansi_handler import ColoredFormatter, ColoredStreamHandler
 
 try:
     from StringIO import StringIO
@@ -26,6 +26,15 @@ class AnsiHandlerTest(unittest.TestCase):
     record2 = logging.makeLogRecord({"name": "", "level": logging.INFO, "levelno": logging.INFO,
                                      "levelname": "INFO", "path": "test_path", "lineno": 0,
                                      "msg": "Test message"})
+    record3 = logging.makeLogRecord({"name": "", "level": logging.ERROR, "levelno": logging.ERROR,
+                                     "levelname": "ERROR", "path": "test_path", "lineno": 0,
+                                     "msg": ['Logging', 'A', 'List']})
+    record4 = logging.makeLogRecord({"name": "", "level": logging.ERROR, "levelno": logging.ERROR,
+                                     "levelname": "ERROR", "path": "test_path", "lineno": 0,
+                                     "msg": ('Logging', 'A', 'Tuple')})
+    record5 = logging.makeLogRecord({"name": "", "level": logging.ERROR, "levelno": logging.ERROR,
+                                     "levelname": "ERROR", "path": "test_path", "lineno": 0,
+                                     "msg": iter(('Logging', 'A', 'Iter'))})
 
     def test_colored_formatter_init(self):
         formatter = ColoredFormatter("%(levelname)s - %(message)s")
@@ -82,3 +91,22 @@ class AnsiHandlerTest(unittest.TestCase):
             if CSI in line:
                 found_csi = True
         self.assertTrue(found_csi, "We are supposed to to have found an ANSI control character %s" % lines)
+
+    def test_ansi_handler_with_list(self):
+        """Tests that the ANSI handler can handle Iterables in the message."""
+        stream = StringIO()
+        formatter = ColoredFormatter("%(levelname)s - %(message)s")
+        handler = ColoredStreamHandler(stream, strip=False, convert=False)
+        handler.setFormatter(formatter)
+        handler.setLevel(logging.INFO)
+
+        handler.emit(AnsiHandlerTest.record3)
+        handler.emit(AnsiHandlerTest.record4)
+        handler.emit(AnsiHandlerTest.record5)
+        handler.flush()
+
+        stream.seek(0)
+        lines = stream.readlines()
+        CSI = '\033[31m'
+        for line in lines:
+            assert CSI in line

--- a/tests.unit/test_ansi_handler.py
+++ b/tests.unit/test_ansi_handler.py
@@ -100,7 +100,6 @@ class AnsiHandlerTest(unittest.TestCase):
         handler.setFormatter(formatter)
         handler.setLevel(logging.INFO)
 
-        handler.emit(AnsiHandlerTest.record5)
         handler.emit(AnsiHandlerTest.record3)
         handler.emit(AnsiHandlerTest.record4)
         handler.emit(AnsiHandlerTest.record5)


### PR DESCRIPTION
Previously, the ansi_handler only accepted strings in the logging record message due to a bug in how the message was retrieved from the record. This change fixes this, allowing any object that `str()` works on to be used as a message in the logging record.

This fix works by converting the message to a str (similar to `LogRecord.getMessage()`) then appending the color code. We cannot call `.getMessage()` directly as that will insert any args into the string, which causes a break later when `.getMessage()` is called again by the logging library (An exception is raised due to attempting to insert an argument into a string without a corresponding `%` placeholder).

closes #143 