### PR TITLE
mkdocs: General DocSite improvements.

### DIFF
--- a/docs/user/features/.pages
+++ b/docs/user/features/.pages
@@ -1,0 +1,1 @@
+title: Advanced Features

--- a/docs/user/gen_api.py
+++ b/docs/user/gen_api.py
@@ -56,8 +56,6 @@ def main():
 
     with mkdocs_gen_files.open("api/.pages", "w") as f:
         print("title: API Reference", file=f)
-        print("nav:", file=f)
-        print("  - ...", file=f)
 
 
 main()

--- a/docs/user/gen_api.py
+++ b/docs/user/gen_api.py
@@ -6,12 +6,14 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 """Python script used to automatically generate API Reference documentation.
+
 Used in conjunction with mkdocs to generate static markdown files for each
 file inside the edk2toollib package for ReadTheDocs hosting.
 """
-import mkdocs_gen_files
 import glob
 import os
+
+import mkdocs_gen_files
 
 
 def main():
@@ -51,6 +53,11 @@ def main():
         # Point the "Edit on Github" button in the docs to point at the source code
         edit_path = os.path.join('..', 'edk2toollib', edit_path)
         mkdocs_gen_files.set_edit_path(filename, edit_path)
+
+    with mkdocs_gen_files.open("api/.pages", "w") as f:
+        print("title: API Reference", file=f)
+        print("nav:", file=f)
+        print("  - ...", file=f)
 
 
 main()

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - navigation
+  - toc
+---
 # Our Philosophy
 
 Edk2 Pytool Library (edk2toollib) is a Tianocore maintained project consisting

--- a/edk2toollib/database/edk2_db.py
+++ b/edk2toollib/database/edk2_db.py
@@ -60,7 +60,6 @@ class Edk2DB:
             db.connection.execute("SELECT * FROM ?", table)
         ```
     """
-
     def __init__(self: 'Edk2DB', db_path: str, pathobj: Edk2Path = None, **kwargs: dict[str,Any]) -> 'Edk2DB':
         """Initializes the database.
 

--- a/edk2toollib/database/edk2_db.py
+++ b/edk2toollib/database/edk2_db.py
@@ -14,6 +14,7 @@ from typing import Any, Optional, Type
 
 from edk2toollib.database.tables import EnvironmentTable
 from edk2toollib.database.tables.base_table import TableGenerator
+from edk2toollib.uefi.edk2.path_utilities import Edk2Path
 
 CREATE_JUNCTION_TABLE = """
 CREATE TABLE IF NOT EXISTS junction (
@@ -56,40 +57,11 @@ class Edk2DB:
         with Edk2DB(Path("path/to/db.db"), edk2path) as db:
             db.register(Parser1(), Parser2(), Parser3())
             db.parse()
-
-        # Run using Memory storage
-        from edk2toollib.database.parsers import *
-        with Edk2DB(Edk2DB.MEM_RW, pathobj=edk2path) as db:
-            db.register(Parser1(), Parser2(), Parser3())
-            db.parse()
-
-        # Run some parsers in clear mode and some in append mode
-        from edk2toollib.database.parsers import *
-        with Edk2DB(Edk2DB.MEM_RW, pathobj=edk2path) as db:
-            db.register(Parser1())
-            db.parse()
-            db.clear_parsers()
-
-            db.register(Parser2(), Parser3())
-            for env in env_list:
-                db.parse(env=env, append=True)
-
-        # Run Queries on specific tables or on the database
-        from edk2toollib.database.queries import *
-        with Edk2DB(Edk2DB.FILE_RW, pathobj=edk2path, db_path=Path("path/to/db.db")) as db:
-            # Run a tinydb Query
-            # https://tinydb.readthedocs.io/en/latest/usage.html#queries
-            query_results = db.table("TABLENAME").search(Query().table_field == "value")
-
-            # Run an advanced query
-            query_results = db.search(AdvancedQuerySubclass(config1 = "x", config2 = "y"))
+            db.connection.execute("SELECT * FROM ?", table)
         ```
     """
-    FILE_RW = 1 # Mode: File storage, Read & Write
-    FILE_RO = 2 # Mode: File storage, Read Only
-    MEM_RW = 3  # Mode: Memory storage, Read & Write
 
-    def __init__(self, mode: int, **kwargs: dict[str,Any]):
+    def __init__(self: 'Edk2DB', db_path: str, pathobj: Edk2Path = None, **kwargs: dict[str,Any]) -> 'Edk2DB':
         """Initializes the database.
 
         Args:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,9 @@ site_description: edk2toollib package documentation
 
 theme:
   name: material
+  features:
+    - navigation.tabs
+    - navigation.indexes
   palette:
     - scheme: default
       toggle:
@@ -73,11 +76,6 @@ watch:
   - 'edk2toollib/'
 
 nav:
-  - Our Philosophy: index.md
-  - Advanced Features:
-    - Edk2 Database: features/edk2_db.md
-    - ANSI Logging: features/logging.ansi_handler.md
-    - Get Host Info: features/utility_functions.GetHostInfo.md
-    - Windows Firmware Policy: features/windows_firmware_policy.md
-    - Build Objects: features/build_objects.md
-  - ...
+  - Home: index.md
+  - ... | features/**/*.md
+  - ... | api/**/*.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,16 @@ copyright: Copyright (c) Microsoft.  All rights reserved
 site_description: edk2toollib package documentation
 
 theme:
-  name: readthedocs
+  name: material
+  palette:
+    - scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
 
 docs_dir: docs/user
 
@@ -71,5 +80,4 @@ nav:
     - Get Host Info: features/utility_functions.GetHostInfo.md
     - Windows Firmware Policy: features/windows_firmware_policy.md
     - Build Objects: features/build_objects.md
-  - API Reference:
-    - ... | flat | api/**/*.md
+  - ...

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,7 +53,7 @@ markdown_extensions:
   - pymdownx.critic
   - pymdownx.details
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
   - pymdownx.inlinehilite
   - pymdownx.magiclink


### PR DESCRIPTION
Associated with #392, but will not close until also completed in edk2-pytool-extensions.

- Changes the theme to material instead of readthedocs as there are no longer any plans to post this to readthedocs.

- Utilizes new features in mkdocs-awesome-pages to allow for a hierarchical sidebar for the API references rather than a flattened list of API references.

- Adds light / dark mode to the docs

- Adds navigation tabs in the header for the main links.

## Sidebar changes

### Before
![image](https://github.com/tianocore/edk2-pytool-library/assets/24388509/a224f1aa-c58b-4eb9-a88e-46e15966c1f0)

### After
![image](https://github.com/tianocore/edk2-pytool-library/assets/24388509/746c3d35-0399-4007-9046-022bbc6aebab)
![image](https://github.com/tianocore/edk2-pytool-library/assets/24388509/4c9779bc-84d3-4ac3-a34f-6c22adaac104)
![image](https://github.com/tianocore/edk2-pytool-library/assets/24388509/80f11d1f-93d8-4e4a-9480-de618db1d51a)
