### PR TITLE
edk2toollib.database.edk2_db: Add env index to large tables

### DIFF
--- a/edk2toollib/database/edk2_db.py
+++ b/edk2toollib/database/edk2_db.py
@@ -26,6 +26,11 @@ CREATE TABLE IF NOT EXISTS junction (
 )
 """
 
+CREATE_JUNCTION_INDEX = """
+CREATE INDEX IF NOT EXISTS junction_idx
+ON junction (env);
+"""
+
 class Edk2DB:
     """A SQLite3 database manager for a EDKII workspace.
 
@@ -97,6 +102,7 @@ class Edk2DB:
             not exist, and a row is added for each call of this command.
         """
         self.connection.execute(CREATE_JUNCTION_TABLE)
+        self.connection.execute(CREATE_JUNCTION_INDEX)
         id = str(uuid.uuid4().hex)
 
         # Create all tables

--- a/edk2toollib/database/tables/instanced_inf_table.py
+++ b/edk2toollib/database/tables/instanced_inf_table.py
@@ -28,7 +28,12 @@ CREATE TABLE IF NOT EXISTS instanced_inf (
     dsc TEXT,
     component TEXT,
     FOREIGN KEY(env) REFERENCES environment(env)
-)
+);
+'''
+
+CREATE_INSTANCED_INF_INDEX = '''
+CREATE INDEX IF NOT EXISTS instanced_inf_idx
+ON instanced_inf (env);
 '''
 
 INSERT_INSTANCED_INF_ROW = '''
@@ -55,6 +60,7 @@ class InstancedInfTable(TableGenerator):
     def create_tables(self, db_cursor: Cursor) -> None:
         """Create the tables necessary for this parser."""
         db_cursor.execute(CREATE_INSTANCED_INF_TABLE)
+        db_cursor.execute(CREATE_INSTANCED_INF_INDEX)
 
     def inf(self, inf: str) -> InfP:
         """Returns a parsed INF object.


### PR DESCRIPTION
Most queries rely on a specific env value when generating results; this commit adds an index on the env column for the junction table as it can get extremely large and index's here will improve performance when filtering on a specific env value.