### PR TITLE
edk2toollib/database: remove autoincrement id

### DIFF
--- a/edk2toollib/database/tables/instanced_fv_table.py
+++ b/edk2toollib/database/tables/instanced_fv_table.py
@@ -18,7 +18,6 @@ from edk2toollib.uefi.edk2.path_utilities import Edk2Path
 
 CREATE_INSTANCED_FV_TABLE = """
 CREATE TABLE IF NOT EXISTS instanced_fv (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
     env INTEGER,
     fv_name TEXT,
     fdf TEXT,

--- a/edk2toollib/database/tables/instanced_fv_table.py
+++ b/edk2toollib/database/tables/instanced_fv_table.py
@@ -48,11 +48,12 @@ class InstancedFvTable(TableGenerator):
         """Create the tables necessary for this parser."""
         db_cursor.execute(CREATE_INSTANCED_FV_TABLE)
 
-    def parse(self, db_cursor: sqlite3.Cursor, pathobj: Edk2Path, id, env) -> None:
+    def parse(self, db_cursor: sqlite3.Cursor, pathobj: Edk2Path, env_id, env) -> None:
         """Parse the workspace and update the database."""
         self.pathobj = pathobj
         self.ws = Path(self.pathobj.WorkspacePath)
         self.env = env
+        self.env_id = env_id
         self.dsc = self.env.get("ACTIVE_PLATFORM", None)
         self.fdf = self.env.get("FLASH_DEFINITION", None)
         self.arch = self.env["TARGET_ARCH"].split(" ")
@@ -77,10 +78,9 @@ class InstancedFvTable(TableGenerator):
                     inf = str(Path(self.pathobj.GetEdk2RelativePathFromAbsolutePath(inf)))
                 inf_list.append(Path(inf).as_posix())
 
-            row = (id, fv, Path(self.fdf).name, self.fdf)
+            row = (self.env_id, fv, Path(self.fdf).name, self.fdf)
             db_cursor.execute(INSERT_INSTANCED_FV_ROW, row)
-            fv_id = db_cursor.lastrowid
 
             for inf in inf_list:
-                row = (id, "instanced_fv", fv_id, "inf", inf)
+                row = (self.env_id, "instanced_fv", fv, "inf", inf)
                 db_cursor.execute(INSERT_JUNCTION_ROW, row)

--- a/edk2toollib/database/tables/instanced_inf_table.py
+++ b/edk2toollib/database/tables/instanced_inf_table.py
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS instanced_inf_junction (
     component TEXT,
     instanced_inf1 TEXT,
     instanced_inf2 TEXT,
-    FOREIGN KEY(env) REFERENCES environment(env),
+    FOREIGN KEY(env) REFERENCES environment(env)
 );
 '''
 
@@ -58,7 +58,7 @@ CREATE INDEX IF NOT EXISTS instanced_inf_source_junction_index ON instanced_inf_
 
 INSERT_INSTANCED_INF_ROW = '''
 INSERT INTO instanced_inf (env, path, class, name, arch, dsc, component)
-VALUES (?, ?, ?, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?, ?);
 '''
 
 INSERT_INF_TABLE_JUNCTION_ROW = '''

--- a/edk2toollib/database/tables/instanced_inf_table.py
+++ b/edk2toollib/database/tables/instanced_inf_table.py
@@ -27,7 +27,33 @@ CREATE TABLE IF NOT EXISTS instanced_inf (
     dsc TEXT,
     component TEXT,
     FOREIGN KEY(env) REFERENCES environment(env)
-)
+);
+'''
+
+CREATE_INSTANCED_INF_TABLE_INDEX = '''
+CREATE INDEX IF NOT EXISTS instanced_inf_index ON instanced_inf (env);
+'''
+
+CREATE_INSTANCED_INF_TABLE_JUNCTION = '''
+CREATE TABLE IF NOT EXISTS instanced_inf_junction (
+    env INTEGER,
+    component TEXT,
+    instanced_inf1 TEXT,
+    instanced_inf2 TEXT,
+    FOREIGN KEY(env) REFERENCES environment(env),
+);
+'''
+
+CREATE_INSTANCED_INF_TABLE_JUNCTION_INDEX = '''
+CREATE INDEX IF NOT EXISTS instanced_inf_junction_index ON instanced_inf_junction (env);
+'''
+
+CREATE_INSTANCED_INF_SOURCE_TABLE_JUNCTION = '''
+CREATE TABLE IF NOT EXISTS instanced_inf_source_junction (env, component, instanced_inf, source);
+'''
+
+CREATE_INSTNACED_INF_SOURCE_TABLE_JUNCTION_INDEX = '''
+CREATE INDEX IF NOT EXISTS instanced_inf_source_junction_index ON instanced_inf_source_junction (env);
 '''
 
 INSERT_INSTANCED_INF_ROW = '''
@@ -35,9 +61,14 @@ INSERT INTO instanced_inf (env, path, class, name, arch, dsc, component)
 VALUES (?, ?, ?, ?, ?, ?, ?)
 '''
 
-INSERT_JUNCTION_ROW = '''
-INSERT INTO junction (env, table1, key1, table2, key2)
-VALUES (?, ?, ?, ?, ?)
+INSERT_INF_TABLE_JUNCTION_ROW = '''
+INSERT INTO instanced_inf_junction (env, component, instanced_inf1, instanced_inf2)
+VALUES (?, ?, ?, ?);
+'''
+
+INSERT_INF_TABLE_SOURCE_JUNCTION_ROW = '''
+INSERT INTO instanced_inf_source_junction (env, component, instanced_inf, source)
+VALUES (?, ?, ?, ?);
 '''
 
 class InstancedInfTable(TableGenerator):
@@ -54,6 +85,11 @@ class InstancedInfTable(TableGenerator):
     def create_tables(self, db_cursor: Cursor) -> None:
         """Create the tables necessary for this parser."""
         db_cursor.execute(CREATE_INSTANCED_INF_TABLE)
+        db_cursor.execute(CREATE_INSTANCED_INF_TABLE_INDEX)
+        db_cursor.execute(CREATE_INSTANCED_INF_TABLE_JUNCTION)
+        db_cursor.execute(CREATE_INSTANCED_INF_TABLE_JUNCTION_INDEX)
+        db_cursor.execute(CREATE_INSTANCED_INF_SOURCE_TABLE_JUNCTION)
+        db_cursor.execute(CREATE_INSTNACED_INF_SOURCE_TABLE_JUNCTION_INDEX)
 
     def inf(self, inf: str) -> InfP:
         """Returns a parsed INF object.
@@ -101,35 +137,24 @@ class InstancedInfTable(TableGenerator):
         Inserts all inf's into the instanced_inf table and links source files and used libraries via the junction
         table.
         """
-        # Must use "execute" so that db_cursor.lastrowid is updated.
+        # Insert all instanced INF rows
         rows = [
             (env_id, e["PATH"], e.get("LIBRARY_CLASS"), e["NAME"], e["ARCH"], e["DSC"], e["COMPONENT"])
             for e in inf_entries
         ]
-        for row in rows:
-            db_cursor.execute(INSERT_INSTANCED_INF_ROW, row)
-        last_inserted_id = db_cursor.lastrowid
+        db_cursor.executemany(INSERT_INSTANCED_INF_ROW, rows)
 
-        # Mapping used for linking libraries together in the junction table so that the value does not need to be
-        # queried, which reduces performance greatly.
-        id_mapping = {}
-        for idx, e in enumerate(inf_entries):
-            id_mapping[e["PATH"], e["COMPONENT"]] = last_inserted_id - len(inf_entries) + 1 + idx
-
-        # Insert rows into the tables
+        # Link isnstaced INF sources
         rows = []
-        for idx, e in enumerate(inf_entries):
-            inf_id = last_inserted_id - len(inf_entries) + 1 + idx
+        for e in inf_entries:
+            rows += [(env_id, e["COMPONENT"], e["PATH"], source) for source in e["SOURCES_USED"]]
+        db_cursor.executemany(INSERT_INF_TABLE_SOURCE_JUNCTION_ROW, rows)
 
-            # Link all source files to this instanced_inf
-            rows += [(env_id, "instanced_inf", inf_id, "source", source) for source in e["SOURCES_USED"]]
-
-            # link other libraries used by this instanced_inf
-            rows += [
-                (env_id, "instanced_inf", inf_id, "instanced_inf", id_mapping.get((library, e["COMPONENT"]), None))
-                for library in e["LIBRARIES_USED"]
-            ]
-        db_cursor.executemany(INSERT_JUNCTION_ROW, rows)
+        # Link instanced INF libraries
+        rows = []
+        for e in inf_entries:
+            rows += [(env_id, e["COMPONENT"], e["PATH"], library) for library in e["LIBRARIES_USED"]]
+        db_cursor.executemany(INSERT_INF_TABLE_JUNCTION_ROW, rows)
 
     def _build_inf_table(self, dscp: DscP):
         """Create the instanced inf entries, including components and libraries.

--- a/edk2toollib/database/tables/instanced_inf_table.py
+++ b/edk2toollib/database/tables/instanced_inf_table.py
@@ -19,7 +19,6 @@ from edk2toollib.uefi.edk2.path_utilities import Edk2Path
 
 CREATE_INSTANCED_INF_TABLE = '''
 CREATE TABLE IF NOT EXISTS instanced_inf (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
     env INTEGER,
     path TEXT,
     class TEXT,

--- a/edk2toollib/database/tables/instanced_inf_table.py
+++ b/edk2toollib/database/tables/instanced_inf_table.py
@@ -52,7 +52,7 @@ CREATE_INSTANCED_INF_SOURCE_TABLE_JUNCTION = '''
 CREATE TABLE IF NOT EXISTS instanced_inf_source_junction (env, component, instanced_inf, source);
 '''
 
-CREATE_INSTNACED_INF_SOURCE_TABLE_JUNCTION_INDEX = '''
+CREATE_INSTANCED_INF_SOURCE_TABLE_JUNCTION_INDEX = '''
 CREATE INDEX IF NOT EXISTS instanced_inf_source_junction_index ON instanced_inf_source_junction (env);
 '''
 
@@ -89,7 +89,7 @@ class InstancedInfTable(TableGenerator):
         db_cursor.execute(CREATE_INSTANCED_INF_TABLE_JUNCTION)
         db_cursor.execute(CREATE_INSTANCED_INF_TABLE_JUNCTION_INDEX)
         db_cursor.execute(CREATE_INSTANCED_INF_SOURCE_TABLE_JUNCTION)
-        db_cursor.execute(CREATE_INSTNACED_INF_SOURCE_TABLE_JUNCTION_INDEX)
+        db_cursor.execute(CREATE_INSTANCED_INF_SOURCE_TABLE_JUNCTION_INDEX)
 
     def inf(self, inf: str) -> InfP:
         """Returns a parsed INF object.
@@ -144,7 +144,7 @@ class InstancedInfTable(TableGenerator):
         ]
         db_cursor.executemany(INSERT_INSTANCED_INF_ROW, rows)
 
-        # Link isnstaced INF sources
+        # Link instanced INF sources
         rows = []
         for e in inf_entries:
             rows += [(env_id, e["COMPONENT"], e["PATH"], source) for source in e["SOURCES_USED"]]

--- a/edk2toollib/database/tables/source_table.py
+++ b/edk2toollib/database/tables/source_table.py
@@ -21,7 +21,6 @@ SOURCE_FILES = ["*.c", "*.h", "*.cpp", "*.asm", "*.s", "*.nasm", "*.masm", "*.rs
 
 CREATE_SOURCE_TABLE = '''
 CREATE TABLE IF NOT EXISTS source (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
     path TEXT UNIQUE,
     license TEXT,
     total_lines INTEGER,

--- a/tests.unit/database/test_instanced_fv_table.py
+++ b/tests.unit/database/test_instanced_fv_table.py
@@ -54,8 +54,7 @@ def test_valid_fdf(empty_tree: Tree):  # noqa: F811
     }
     db.parse(env)
 
-    fv_id = db.connection.execute("SELECT id FROM instanced_fv WHERE fv_name = 'infformat'").fetchone()[0]
-    rows = db.connection.execute("SELECT key2 FROM junction where key1 == ?", (fv_id,)).fetchall()
+    rows = db.connection.execute("SELECT key2 FROM junction where key1 == 'infformat'").fetchall()
 
     assert len(rows) == 5
     assert sorted(rows) == sorted([


### PR DESCRIPTION
Removes autoincrementing primary keys from `instanced_fv`, `instanced_inf` and `source` tables. Tables depending on an autoincremented index as a foreign key end up breaking when doing a naive merge of two databases as the index is automatically updated in the table where it is the primary key, but it is not updated in the table where it is a foreign key, thus breaking the association.

To support merging two databases where we will never know the true tables in the database (A developer can register a subset of provided tables or create their own), core tables should not use autoincremented primary keys.

## instanced_fv table

This removal was simple as there was no existing dependencies that utilized the auto-incremented primary key. Getting the same association can be done via combining the `env` and `fv_name` columns.

## instanced_inf table

This removal is more complex as the autoincremented id was directly used when associating the inf's with each other (when forming a dependency list). Getting the same association can be done via combining the `env` and `component` columns. This change made it such that the provided `junction` table does not work, and an `instanced_inf_junction` table was created to support this.

## source table

This removal was simple as there was no existing dependencies that utilized the auto-incremented primary key. Getting the same association can be done via the `path` column.