### PR TITLE
edk2toollib/uefi/edk2/parsers: enhancements

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/base_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/base_parser.py
@@ -240,12 +240,12 @@ class BaseParser(object):
             return (ivalue != ivalue2) and (value != value2)
 
         # check to make sure we only have digits from here on out
-        if not isinstance(value, int) and not str.isdigit(value):
+        if not isinstance(ivalue, int) and not str.isdigit(value):
             self.Logger.error(f"{self.__class__}: Unknown value: {value} {ivalue.__class__}")
             self.Logger.debug(f"{self.__class__}: Conditional: {value} {cond}{value2}")
             raise ValueError("Unknown value")
 
-        if not isinstance(value2, int) and not str.isdigit(value2):
+        if not isinstance(ivalue2, int) and not str.isdigit(value2):
             self.Logger.error(f"{self.__class__}: Unknown value: {value2} {ivalue2}")
             self.Logger.debug(f"{self.__class__}: Conditional: {value} {cond} {value2}")
             raise ValueError("Unknown value")

--- a/edk2toollib/uefi/edk2/parsers/base_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/base_parser.py
@@ -240,6 +240,11 @@ class BaseParser(object):
             return (ivalue != ivalue2) and (value != value2)
 
         # check to make sure we only have digits from here on out
+        if value.upper() in ["TRUE", "FALSE"] or value2.upper() in ["TRUE", "FALSE"]:
+            self.Logger.error(f"Invalid comparison: {value} {cond} {value2}")
+            self.Logger.debug(f"Invalid comparison: {value} {cond} {value2}")
+            raise ValueError("Invalid comparison")
+
         if not isinstance(ivalue, int) and not str.isdigit(value):
             self.Logger.error(f"{self.__class__}: Unknown value: {value} {ivalue.__class__}")
             self.Logger.debug(f"{self.__class__}: Conditional: {value} {cond}{value2}")

--- a/edk2toollib/uefi/edk2/parsers/dsc_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/dsc_parser.py
@@ -114,7 +114,7 @@ class DscParser(HashFileParser):
                     self.Libs.append(p)
                     self.Logger.debug("Found Library in a 64bit BuildOptions Section: %s" % p)
                 elif self.RegisterPcds(line_resolved):
-                    self.Logger.debug("Found a Pcd in a 64bit Module Override section: %s" % p[0].strip())
+                    self.Logger.debug("Found a Pcd in a 64bit Module Override section")
             else:
                 if (".inf" in line_resolved.lower()):
                     p = self.ParseInfPathMod(line_resolved)
@@ -137,7 +137,7 @@ class DscParser(HashFileParser):
                         self.LibsEnhanced.append({'file': os.path.normpath(file_name), 'lineno': lineno, 'data': p})
                     self.Logger.debug("Found Library in a 32bit BuildOptions Section: %s" % p)
                 elif self.RegisterPcds(line_resolved):
-                    self.Logger.debug("Found a Pcd in a 32bit Module Override section: %s" % p[0].strip())
+                    self.Logger.debug("Found a Pcd in a 32bit Module Override section")
 
             else:
                 if (".inf" in line_resolved.lower()):
@@ -160,7 +160,7 @@ class DscParser(HashFileParser):
                     self.Libs.append(p)
                     self.Logger.debug("Found Library in a BuildOptions Section: %s" % p)
                 elif self.RegisterPcds(line_resolved):
-                    self.Logger.debug("Found a Pcd in a Module Override section: %s" % p[0].strip())
+                    self.Logger.debug("Found a Pcd in a Module Override section")
 
             else:
                 if (".inf" in line_resolved.lower()):
@@ -182,7 +182,7 @@ class DscParser(HashFileParser):
         # process line in PCD section
         elif (self.CurrentSection.upper().startswith("PCDS")):
             if self.RegisterPcds(line_resolved):
-                self.Logger.debug("Found a Pcd in a PCD section: %s" % p[0].strip())
+                self.Logger.debug("Found a Pcd in a PCD section")
             return (line_resolved, [], None)
         else:
             return (line_resolved, [], None)
@@ -530,6 +530,6 @@ class DscParser(HashFileParser):
             p = line.partition('|')
             self.Pcds.append(p[0].strip())
             self.PcdValueDict[p[0].strip()] = p[2].strip()
-            self.Logger.debug("Found a Pcd in a 64bit Module Override section: %s" % p[0].strip())
+            self.Logger.debug("Found a Pcd: %s" % p[0].strip())
             return True
         return False

--- a/edk2toollib/uefi/edk2/parsers/dsc_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/dsc_parser.py
@@ -113,12 +113,7 @@ class DscParser(HashFileParser):
                     p = self.ParseInfPathLib(line_resolved)
                     self.Libs.append(p)
                     self.Logger.debug("Found Library in a 64bit BuildOptions Section: %s" % p)
-                elif "tokenspaceguid" in line_resolved.lower() and \
-                        line_resolved.count('|') > 0 and line_resolved.count('.') > 0:
-                    # should be a pcd statement
-                    p = line_resolved.partition('|')
-                    self.Pcds.append(p[0].strip())
-                    self.PcdValueDict[p[0].strip()] = p[2].strip()
+                elif self.RegisterPcds(line_resolved):
                     self.Logger.debug("Found a Pcd in a 64bit Module Override section: %s" % p[0].strip())
             else:
                 if (".inf" in line_resolved.lower()):
@@ -141,12 +136,7 @@ class DscParser(HashFileParser):
                     if file_name is not None and lineno is not None:
                         self.LibsEnhanced.append({'file': os.path.normpath(file_name), 'lineno': lineno, 'data': p})
                     self.Logger.debug("Found Library in a 32bit BuildOptions Section: %s" % p)
-                elif "tokenspaceguid" in line_resolved.lower() and \
-                        line_resolved.count('|') > 0 and line_resolved.count('.') > 0:
-                    # should be a pcd statement
-                    p = line_resolved.partition('|')
-                    self.Pcds.append(p[0].strip())
-                    self.PcdValueDict[p[0].strip()] = p[2].strip()
+                elif self.RegisterPcds(line_resolved):
                     self.Logger.debug("Found a Pcd in a 32bit Module Override section: %s" % p[0].strip())
 
             else:
@@ -169,12 +159,7 @@ class DscParser(HashFileParser):
                     p = self.ParseInfPathLib(line_resolved)
                     self.Libs.append(p)
                     self.Logger.debug("Found Library in a BuildOptions Section: %s" % p)
-                elif "tokenspaceguid" in line_resolved.lower() and \
-                        line_resolved.count('|') > 0 and line_resolved.count('.') > 0:
-                    # should be a pcd statement
-                    p = line_resolved.partition('|')
-                    self.Pcds.append(p[0].strip())
-                    self.PcdValueDict[p[0].strip()] = p[2].strip()
+                elif self.RegisterPcds(line_resolved):
                     self.Logger.debug("Found a Pcd in a Module Override section: %s" % p[0].strip())
 
             else:
@@ -196,12 +181,7 @@ class DscParser(HashFileParser):
             return (line_resolved, [], None)
         # process line in PCD section
         elif (self.CurrentSection.upper().startswith("PCDS")):
-            if "tokenspaceguid" in line_resolved.lower() and \
-                    line_resolved.count('|') > 0 and line_resolved.count('.') > 0:
-                # should be a pcd statement
-                p = line_resolved.partition('|')
-                self.Pcds.append(p[0].strip())
-                self.PcdValueDict[p[0].strip()] = p[2].strip()
+            if self.RegisterPcds(line_resolved):
                 self.Logger.debug("Found a Pcd in a PCD section: %s" % p[0].strip())
             return (line_resolved, [], None)
         else:
@@ -213,6 +193,8 @@ class DscParser(HashFileParser):
             return ("", [])
 
         # this line needs to be here to resolve any symbols inside the !include lines, if any
+        self.RegisterPcds(line_stripped)
+        line_stripped = self.ReplacePcds(line_stripped)
         line_resolved = self.ReplaceVariables(line_stripped)
         if (self.ProcessConditional(line_resolved)):
             # was a conditional
@@ -333,6 +315,8 @@ class DscParser(HashFileParser):
                 # otherwise, raise the exception and act normally
                 if not self._no_fail_mode:
                     raise
+        # Reset the PcdValueDict as this was just to find any Defines.
+        self.PcdValueDict = {}
 
     def _parse_libraries(self):
         """Builds a lookup table of all possible library instances depending on scope.
@@ -535,3 +519,17 @@ class DscParser(HashFileParser):
         They are not all guaranteed to be DSC files
         """
         return self._dsc_file_paths
+
+    def RegisterPcds(self, line):
+        """Reads the line and registers any PCDs found."""
+        if ("tokenspaceguid" in line.lower() and
+            line.count('|') > 0 and
+            line.count('.') > 0):
+
+            # should be a pcd statement
+            p = line.partition('|')
+            self.Pcds.append(p[0].strip())
+            self.PcdValueDict[p[0].strip()] = p[2].strip()
+            self.Logger.debug("Found a Pcd in a 64bit Module Override section: %s" % p[0].strip())
+            return True
+        return False

--- a/tests.unit/parsers/test_base_parser.py
+++ b/tests.unit/parsers/test_base_parser.py
@@ -229,6 +229,13 @@ class TestBaseParserConditionals(unittest.TestCase):
         self.assertTrue(parser.ProcessConditional("!IF 0x20 == 32"))
         self.assertTrue(parser.InActiveCode())
         self.assertTrue(parser.ProcessConditional("!endif"))
+        # check that hex comparisons work
+        self.assertTrue(parser.ProcessConditional("!IF 0x20 > 0x20"))
+        self.assertFalse(parser.InActiveCode())
+        self.assertTrue(parser.ProcessConditional("!endif"))
+        self.assertTrue(parser.ProcessConditional("!IF 0x20 >= 0x20"))
+        self.assertTrue(parser.InActiveCode())
+        self.assertTrue(parser.ProcessConditional("!endif"))
 
     def test_process_conditional_greater_than(self):
         parser = BaseParser("")

--- a/tests.unit/parsers/test_dsc_parser.py
+++ b/tests.unit/parsers/test_dsc_parser.py
@@ -154,28 +154,3 @@ class TestDscParserIncludes(unittest.TestCase):
             self.assertEqual(parser.LocalVars["INCLUDED"], "TRUE")  # make sure we got the defines
         finally:
             os.chdir(cwd)
-
-    def test_handle_integer_comparisons(self):
-        DSC_FILE = '''
-[Defines]
-DEFINE SERIAL_REGISTER_BASE = 0xFEDC9000
-[PcdsFixedAtBuild]
-!if $(SERIAL_REGISTER_BASE) == 0x3F8 OR $(SERIAL_REGISTER_BASE) == 0x3E8
-gEfiModulePkgTokenSpaceGuid.MyValue|0x04
-# UART0 is COM2/4 IRQ3
-!elseif $(SERIAL_REGISTER_BASE) == 0x2F8 OR $(SERIAL_REGISTER_BASE) == 0x2E8
-gEfiModulePkgTokenSpaceGuid.MyValue|0x03
-!endif
-!if $(SERIAL_REGISTER_BASE) >= 0x10000
-gEfiMdeModulePkgTokenSpaceGuid.PcdSerialUseMmio|TRUE
-gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterStride|4
-gEfiMdeModulePkgTokenSpaceGuid.PcdSerialClockRate|48000000
-!else
-'''
-        import pathlib
-        workspace = tempfile.mkdtemp()
-        dsc = pathlib.Path(workspace) / "dsc.dsc"
-        dsc.write_text(DSC_FILE)
-        parser = DscParser()
-        parser.SetEdk2Path(Edk2Path(workspace, []))
-        parser.ParseFile(dsc)

--- a/tests.unit/parsers/test_dsc_parser.py
+++ b/tests.unit/parsers/test_dsc_parser.py
@@ -154,3 +154,28 @@ class TestDscParserIncludes(unittest.TestCase):
             self.assertEqual(parser.LocalVars["INCLUDED"], "TRUE")  # make sure we got the defines
         finally:
             os.chdir(cwd)
+
+    def test_handle_integer_comparisons(self):
+        DSC_FILE = '''
+[Defines]
+DEFINE SERIAL_REGISTER_BASE = 0xFEDC9000
+[PcdsFixedAtBuild]
+!if $(SERIAL_REGISTER_BASE) == 0x3F8 OR $(SERIAL_REGISTER_BASE) == 0x3E8
+gEfiModulePkgTokenSpaceGuid.MyValue|0x04
+# UART0 is COM2/4 IRQ3
+!elseif $(SERIAL_REGISTER_BASE) == 0x2F8 OR $(SERIAL_REGISTER_BASE) == 0x2E8
+gEfiModulePkgTokenSpaceGuid.MyValue|0x03
+!endif
+!if $(SERIAL_REGISTER_BASE) >= 0x10000
+gEfiMdeModulePkgTokenSpaceGuid.PcdSerialUseMmio|TRUE
+gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterStride|4
+gEfiMdeModulePkgTokenSpaceGuid.PcdSerialClockRate|48000000
+!else
+'''
+        import pathlib
+        workspace = tempfile.mkdtemp()
+        dsc = pathlib.Path(workspace) / "dsc.dsc"
+        dsc.write_text(DSC_FILE)
+        parser = DscParser()
+        parser.SetEdk2Path(Edk2Path(workspace, []))
+        parser.ParseFile(dsc)


### PR DESCRIPTION
Improves the following parsers in the following ways:

`base_parser.py`: Properly uses ivalue (int value) to check if the string representation of a value was correctly converted to an integer ('1' to 1, '0x0' to 0, etc) when evaluating conditionals

`dsc_parser.py`: register pcds when performing the initial parse responsible for finding define statements. This is necessary to evaluate conditionals that use pcds.