### PR TITLE
[REBASE&FF] Multiple table / parser updates

### DIFF
--- a/edk2toollib/database/tables/inf_table.py
+++ b/edk2toollib/database/tables/inf_table.py
@@ -23,7 +23,8 @@ CREATE TABLE IF NOT EXISTS inf (
     path TEXT PRIMARY KEY,
     guid TEXT,
     library_class TEXT,
-    package TEXT
+    package TEXT,
+    module_type TEXT
 );
 '''
 
@@ -33,8 +34,8 @@ VALUES (?, ?, ?, ?, ?)
 '''
 
 INSERT_INF_ROW = '''
-INSERT OR REPLACE INTO inf (path, guid, library_class, package)
-VALUES (?, ?, ?, ?)
+INSERT OR REPLACE INTO inf (path, guid, library_class, package, module_type)
+VALUES (?, ?, ?, ?, ?)
 '''
 
 class InfTable(TableGenerator):
@@ -71,7 +72,7 @@ class InfTable(TableGenerator):
 
         # Insert the data into the database
         for inf in inf_entries:
-            row = (inf["PATH"], inf["GUID"], inf["LIBRARY_CLASS"], inf["PACKAGE"])
+            row = (inf["PATH"], inf["GUID"], inf["LIBRARY_CLASS"], inf["PACKAGE"], inf["MODULE_TYPE"])
             db_cursor.execute(INSERT_INF_ROW, row)
 
             for library in inf["LIBRARIES_USED"]:
@@ -113,5 +114,6 @@ class InfTable(TableGenerator):
         data["PPIS_USED"] = inf_parser.PpisUsed
         data["PCDS_USED"] = inf_parser.PcdsUsed
         data["PACKAGE"] = pkg
+        data["MODULE_TYPE"] = inf_parser.Dict.get("MODULE_TYPE", None)
 
         return data

--- a/edk2toollib/database/tables/instanced_inf_table.py
+++ b/edk2toollib/database/tables/instanced_inf_table.py
@@ -164,7 +164,12 @@ class InstancedInfTable(TableGenerator):
         """
         inf_entries = []
         for (inf, scope, overrides) in dscp.Components:
-            logging.debug(f"Parsing Component: [{inf}]")
+            # Ignore components built with an architecture that is not in TARGET_ARCH
+            arch = scope.split(".")[0].upper()
+            if arch not in self.arch:
+                continue
+
+            logging.debug(f"Parsing Component: [{arch}][{inf}]")
             infp = InfP().SetEdk2Path(self.pathobj)
             infp.ParseFile(inf)
 

--- a/edk2toollib/database/tables/package_table.py
+++ b/edk2toollib/database/tables/package_table.py
@@ -50,6 +50,10 @@ class PackageTable(TableGenerator):
         for file in Path(pathobj.WorkspacePath).rglob("*.dec"):
             pkg = pathobj.GetContainingPackage(str(file))
             containing_repo = "BASE"
+            if "origin" in repo.remotes:
+                containing_repo = repo.remotes.origin.url.split("/")[-1].split(".git")[0].upper()
+            elif len(repo.remotes) > 0:
+                containing_repo = repo.remotes[0].url.split("/")[-1].split(".git")[0].upper()
             if repo:
                 for submodule in repo.submodules:
                     if submodule.abspath in str(file):

--- a/edk2toollib/uefi/edk2/parsers/inf_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/inf_parser.py
@@ -104,7 +104,15 @@ class InfParser(HashFileParser):
             if (sline is None or len(sline) < 1):
                 continue
 
-            if InDefinesSection:
+            sline = self.ReplaceVariables(sline)
+
+            if sline.strip().startswith("DEFINE"):
+                tokens = sline.strip().replace("DEFINE", "").split('=', 1)
+                self.LocalVars[tokens[0].strip()] = tokens[1].strip()
+                self.Logger.info(f"Key,values found for local vars: {tokens[0].strip()}, {tokens[1].strip()}")
+                continue
+
+            elif InDefinesSection:
                 if sline.strip()[0] == '[':
                     InDefinesSection = False
                 else:
@@ -222,11 +230,21 @@ class InfParser(HashFileParser):
         arch_list = []
 
         for line in self.Lines:
+            line = self.StripComment(line)
+
             if line.strip() == "":
                 continue
 
             if line.strip().startswith("#"):
                 continue
+
+            if line.strip().startswith("DEFINE"):
+                tokens = line.strip().replace("DEFINE", "").split('=', 1)
+                self.LocalVars[tokens[0].strip()] = tokens[1].strip()
+                self.Logger.info(f"Key,values found for local vars: {tokens[0].strip()}, {tokens[1].strip()}")
+                continue
+
+            line = self.ReplaceVariables(line)
 
             match = self.SECTION_LIBRARY.findall(line)
             if match:

--- a/tests.unit/database/common.py
+++ b/tests.unit/database/common.py
@@ -79,7 +79,7 @@ def create_fdf_file(file_path, **kwargs):
 def create_dsc_file(file_path, **kwargs):
     """Makes a DSC with default values that can be overwritten via kwargs."""
     # Make default values.
-    defines = {}
+    defines = {"SUPPORTED_ARCHITECTURES": "IA32|X64|AARCH64"}
     libs = ["TestLib|TestPkg/Library/TestLibNull.inf"]
     comps = ["TestPkg/Drivers/TestDriver.inf"]
 

--- a/tests.unit/database/test_instanced_inf_table.py
+++ b/tests.unit/database/test_instanced_inf_table.py
@@ -185,7 +185,7 @@ def test_scoped_libraries1(empty_tree: Tree):
     results = db.connection.execute('SELECT source FROM instanced_inf_source_junction').fetchall()
     assert len(results) == 3
     for source, in results:
-        assert source in ["File1.c", "File2.c", "File3.c"]
+        assert Path(source).name in ["File1.c", "File2.c", "File3.c"]
 
 def test_scoped_libraries2(empty_tree: Tree):
     """Ensure that the correct libraries in regards to scoping.

--- a/tests.unit/database/test_package_table.py
+++ b/tests.unit/database/test_package_table.py
@@ -35,9 +35,9 @@ def test_basic_parse(tmp_path):
     results = db.connection.cursor().execute("SELECT * FROM package").fetchall()
 
     to_pass = {
-        ("QemuPkg", "BASE"): False,
-        ("QemuSbsaPkg", "BASE"): False,
-        ("QemuQ35Pkg", "BASE"): False,
+        ("QemuPkg", "MU_TIANO_PLATFORMS"): False,
+        ("QemuSbsaPkg", "MU_TIANO_PLATFORMS"): False,
+        ("QemuQ35Pkg", "MU_TIANO_PLATFORMS"): False,
         ("SetupDataPkg", "Features/CONFIG"): False,
     }
     for result in results:

--- a/tests.unit/parsers/test_inf_parser.py
+++ b/tests.unit/parsers/test_inf_parser.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+from edk2toollib.uefi.edk2.parsers.inf_parser import InfParser
+
+INF_EXAMPLE1 = """
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = TestLib
+  FILE_GUID                      = ffffffff-ffff-ffff-ffff-ffffffffffff
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = BaseTestLib
+
+[Sources]
+# [Binaries]
+  File1.c
+
+[Sources.common]
+  File2.c
+
+[Sources.IA32]
+  # Random Comment
+  File3.c
+  # File999.c
+
+[sources.IA32, sources.X64]
+  File4.c
+
+[LibraryClasses]
+  Library1
+
+[Binaries]
+  Binary1.efi
+
+[LibraryClasses.common]
+  Library2
+
+[LibraryClasses.IA32]
+  Library3
+
+[LibraryClasses.IA32, LibraryClasses.X64]
+  Library4
+"""
+def test_inf_parser_scoped_libraryclasses(tmp_path: Path):
+    """Test that we accurately detect scoped library classes."""
+    inf_path = tmp_path / "test.inf"
+    inf_path.touch()
+    inf_path.write_text(INF_EXAMPLE1)
+
+    infp = InfParser()
+    infp.ParseFile(inf_path)
+
+    assert sorted(infp.get_libraries([])) == sorted(["Library1", "Library2"])
+    assert sorted(infp.get_libraries(["Common"])) == sorted(["Library1", "Library2"])
+    assert sorted(infp.get_libraries(["IA32"])) == sorted(["Library1", "Library2", "Library3", "Library4"])
+    assert sorted(infp.get_libraries(["X64"])) == sorted(["Library1", "Library2", "Library4"])
+
+def test_inf_parser_scoped_sources(tmp_path: Path):
+    """Test that we accurately detect scoped sources."""
+    inf_path = tmp_path / "test.inf"
+    inf_path.touch()
+    inf_path.write_text(INF_EXAMPLE1)
+
+    infp = InfParser()
+    infp.ParseFile(inf_path)
+
+    assert sorted(infp.get_sources([])) == sorted(["File1.c", "File2.c"])
+    assert sorted(infp.get_sources(["Common"])) == sorted(["File1.c", "File2.c"])
+    assert sorted(infp.get_sources(["IA32"])) == sorted(["File1.c", "File2.c", "File3.c", "File4.c"])
+    assert sorted(infp.get_sources(["X64"])) == sorted(["File1.c", "File2.c", "File4.c"])


### PR DESCRIPTION
Contains multiple commits to improve `instanced_table`, `instanced_inf_table`, and `dsc_parser`.

## Commit 1: inf_table.py: resolve dot-dot paths in source files

Updates inf_table.py to resolve dot-dot paths in source files before inserting it into the database to ensure the path is a valid edk2 package path relative path. Source files in the database are now edk2 package relative rather than inf relative.

## Commit 2: instanced_inf_table.py: Filter on TARGET_ARCH

The dsc_parser is architecture agnostic and resolves the dsc file for all architectures it supports. This means the instanced_inf_table must filter the results to only the architectures specified by the Settings file.

## Commit 3: dsc_parser.py: use SUPPORTED_ARCHITECTURES

The dsc_parser relied on TARGET_ARCH when creating scoped libraries and components, but it should rely on SUPPORTED_ARCHITECTURES which provides information true to the DSC.

## Commit 4: inf parsing: Add support for scoped source files

Adds additional parsing to the inf_parser to support scoped source files
which can be retrieved via the function get_sources(arch_list), which
will return all sources used for a given arch(s). Re-writes the logic
that does the same for scoped libraries to make it more extensible, but
no user facing changes.

Updates instanced_inf_table to use the new function to get the sources.

## Commit 5: inf_parser: Add ReplaceVariable support

Previously, the INF parser did not support detecting DEFINE variables or
replacing $(variable) with the value of the variable, similar to other
parsers. This change adds support for this feature, and assocaited tests
to ensure it works as expected.