### PR TITLE
Update Supported Python versions to 3.10, 3.11, and 3.12

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,9 +48,9 @@ body:
       description: "Note: Bug fixes are only supported on these Python versions."
       multiple: true
       options:
-        - Python 3.9
         - Python 3.10
         - Python 3.11
+        - Python 3.12
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/VariableProducer.yml
+++ b/.github/workflows/VariableProducer.yml
@@ -14,7 +14,7 @@ on:
         value: ${{ jobs.produce.outputs.node-versions }}
 
 env:
-  pythonversions: "['3.11', '3.10', '3.9']" # Keep Python Versions in descending order
+  pythonversions: "['3.12', '3.11', '3.10']" # Keep Python Versions in descending order
   nodeversions: "['19']"
 
 jobs:

--- a/docs/contributor/python_release.md
+++ b/docs/contributor/python_release.md
@@ -31,6 +31,7 @@ classifiers=[
     "Programming Language :: Python :: 3.11"
 ]
 ```
+
 ### bug_report.yml
 
 Update the supported python versions in the entry with `id: py_version`

--- a/docs/contributor/python_release.md
+++ b/docs/contributor/python_release.md
@@ -9,17 +9,16 @@ released (3.9, 3.10, etc).
 Each individual step will be a different section below and be associated with
 a specific file that must be updated.
 
-### setup.py
+### pyproject.toml
 
 This file is responsible for the release process to pypi. We want to make sure
-we keep the required version for our pypi releases up to date. Within
-`setuptools.setup()` locate the line `python_requires = "XXX"` and update it to
-the next version.
+we keep the required version for our pypi releases up to date. Update
+`requires-python` to the minimum required python.
 
 We typically support the last three minor versions; barring any special
 exceptions, if the newest minor version is 3.11, then overall we will support
 3.9, 3.10, and 3.11. Therefore you should update the line to
-`python_requires = ">=3.9.0"`.
+`python-requires = ">=3.9"`.
 
 Additionally, we must update the classifiers section to show the three
 supported python versions:
@@ -32,3 +31,14 @@ classifiers=[
     "Programming Language :: Python :: 3.11"
 ]
 ```
+### bug_report.yml
+
+Update the supported python versions in the entry with `id: py_version`
+
+### VariableProducer.yml
+
+Update `pythonversions` to the support versions
+
+### readme.md
+
+Update the python versions in the `Current Status` section

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dynamic = ["version"]
 description = "Python library supporting UEFI EDK2 firmware development"
 readme = {file = "readme.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}
+requires-python = ">=3.10"
 dependencies = [
     "pyasn1 >= 0.4.8",
     "pyasn1-modules >= 0.2.8",
@@ -22,9 +23,9 @@ classifiers=[
         "Operating System :: OS Independent",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11"
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12"
     ]
 
 [project.urls]

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ Supported Versions
 |  [Ubuntu-Latest]   |  Python 3.10  |  [![ci]][_ci]           |
 |  [Ubuntu-Latest]   |  Python 3.11  |  [![ci]][_ci]           |
 |  [Ubuntu-Latest]   |  Python 3.12  |  [![ci]][_ci]           |
-|  [MacOS-Latest]    |  Python 3.10   |  [![coming_soon]][_ci]  |
+|  [MacOS-Latest]    |  Python 3.10  |  [![coming_soon]][_ci]  |
 |  [MacOS-Latest]    |  Python 3.11  |  [![coming_soon]][_ci]  |
 |  [MacOS-Latest]    |  Python 3.12  |  [![coming_soon]][_ci]  |
 

--- a/readme.md
+++ b/readme.md
@@ -26,15 +26,15 @@ Supported Versions
 
 |  Host Type         |  Toolchain    |  Status
 |  :---------------  |  :----------  |  :--------------------  |
-|  [Windows-Latest]  |  Python 3.9   |  [![ci]][_ci]           |
 |  [Windows-Latest]  |  Python 3.10  |  [![ci]][_ci]           |
 |  [Windows-Latest]  |  Python 3.11  |  [![ci]][_ci]           |
-|  [Ubuntu-Latest]   |  Python 3.9   |  [![ci]][_ci]           |
+|  [Windows-Latest]  |  Python 3.12  |  [![ci]][_ci]           |
 |  [Ubuntu-Latest]   |  Python 3.10  |  [![ci]][_ci]           |
 |  [Ubuntu-Latest]   |  Python 3.11  |  [![ci]][_ci]           |
-|  [MacOS-Latest]    |  Python 3.9   |  [![coming_soon]][_ci]  |
-|  [MacOS-Latest]    |  Python 3.10  |  [![coming_soon]][_ci]  |
+|  [Ubuntu-Latest]   |  Python 3.12  |  [![ci]][_ci]           |
+|  [MacOS-Latest]    |  Python 3.10   |  [![coming_soon]][_ci]  |
 |  [MacOS-Latest]    |  Python 3.11  |  [![coming_soon]][_ci]  |
+|  [MacOS-Latest]    |  Python 3.12  |  [![coming_soon]][_ci]  |
 
 ### Current Release
 


### PR DESCRIPTION
Updates all documentation and testing to use python 3.10, 3.11, and 3.12. 

Additionally adds a python-requires section to the pyproject.toml, to ensure a proper error if someone tries to pip install edk2-pytool-library v0.19.0 on a python version less than 3.10