### PR TITLE
base_parser.py: conditional evaluation bugfix

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/base_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/base_parser.py
@@ -240,7 +240,8 @@ class BaseParser(object):
             return (ivalue != ivalue2) and (value != value2)
 
         # check to make sure we only have digits from here on out
-        if (isinstance(value, str) and value.upper() in ["TRUE", "FALSE"]) or (isinstance(value, str) and value2.upper() in ["TRUE", "FALSE"]):
+        if (isinstance(value, str) and value.upper() in ["TRUE", "FALSE"]) \
+            or (isinstance(value, str) and value2.upper() in ["TRUE", "FALSE"]):
             self.Logger.error(f"Invalid comparison: {value} {cond} {value2}")
             self.Logger.debug(f"Invalid comparison: {value} {cond} {value2}")
             raise ValueError("Invalid comparison")

--- a/edk2toollib/uefi/edk2/parsers/base_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/base_parser.py
@@ -240,7 +240,7 @@ class BaseParser(object):
             return (ivalue != ivalue2) and (value != value2)
 
         # check to make sure we only have digits from here on out
-        if value.upper() in ["TRUE", "FALSE"] or value2.upper() in ["TRUE", "FALSE"]:
+        if (isinstance(value, str) and value.upper() in ["TRUE", "FALSE"]) or (isinstance(value, str) and value2.upper() in ["TRUE", "FALSE"]):
             self.Logger.error(f"Invalid comparison: {value} {cond} {value2}")
             self.Logger.debug(f"Invalid comparison: {value} {cond} {value2}")
             raise ValueError("Invalid comparison")

--- a/tests.unit/parsers/test_base_parser.py
+++ b/tests.unit/parsers/test_base_parser.py
@@ -510,7 +510,6 @@ class TestBaseParserConditionals(unittest.TestCase):
         self.assertTrue(parser.ProcessConditional('!endif'))
 
 
-
 class TestBaseParserGuids(unittest.TestCase):
 
     def test_is_guid(self):

--- a/tests.unit/parsers/test_base_parser.py
+++ b/tests.unit/parsers/test_base_parser.py
@@ -488,6 +488,28 @@ class TestBaseParserConditionals(unittest.TestCase):
 
         parser.ResetParserState()
 
+    def test_conditional_with_variable(self):
+        ''' Makes sure conversions are correct when using variables '''
+        parser = BaseParser("")
+        parser.LocalVars = {"MAX_SOCKET": '4', 'TARGET': 'DEBUG'}
+
+        self.assertTrue(parser.ProcessConditional('!if $(MAX_SOCKET) <= 4'))
+        self.assertTrue(parser.InActiveCode())
+        self.assertTrue(parser.ProcessConditional('!endif'))
+
+        self.assertTrue(parser.ProcessConditional('!if $(TARGET) == "DEBUG" && $(MAX_SOCKET) <= 4'))
+        self.assertTrue(parser.InActiveCode())
+        self.assertTrue(parser.ProcessConditional('!endif'))
+
+        self.assertTrue(parser.ProcessConditional('!if $(MAX_SOCKET) <= 3'))
+        self.assertFalse(parser.InActiveCode())
+        self.assertTrue(parser.ProcessConditional('!endif'))
+
+        self.assertTrue(parser.ProcessConditional('!if ($(TARGET) == "RELEASE") && ($(MAX_SOCKET) <= 4)'))
+        self.assertFalse(parser.InActiveCode())
+        self.assertTrue(parser.ProcessConditional('!endif'))
+
+
 
 class TestBaseParserGuids(unittest.TestCase):
 


### PR DESCRIPTION
recent changes to conditional evaluations to support evaluating non decimal integers such as hex strings broke the ability to evaulate define macro replacements that are integers. This is a bugfix to keep that support along with additional tests to ensure it does not break in the future.