### PR TITLE
path_utilities: Remove Nested package exceptions

### DIFF
--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -105,6 +105,15 @@ class Edk2Path(object):
         #    is relative (nested) to each other.
         # 3. Raise an Exception if two packages are found to be nested.
         #
+        if "PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES" in os.environ:
+            warning = "PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES is no longer used by edk2-pytool-library, but is "\
+                      "detected in your environment. Please remove this environment variable."
+            self.Logger.log(logging.WARNING, warning)
+        if "PYTOOL_IGNORE_KNOWN_BAD_NESTED_PACKAGES" == os.environ:
+            warning = "PYTOOL_IGNORE_KNOWN_BAD_NESTED_PACKAGES is no longer used by edk2-pytool-library, but is " \
+                      "detected in your environment. Please remove this environment variable."
+            self.Logger.log(logging.WARNING, warning)
+
         package_path_packages = {}
         for package_path in self._package_path_list:
             package_path_packages[package_path] = \

--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -119,7 +119,7 @@ class Edk2Path(object):
                         self.logger.log(
                             logging.DEBUG,
                             f"[{str(package)}] and [{str(comp_package)}] are nested. Nested packages are not allowed "
-                            "and may result in incorrect converions from absolute path to edk2 package path relative "
+                            "and may result in incorrect conversions from absolute path to edk2 package path relative "
                             "paths."
                         )
 

--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -34,16 +34,6 @@ class Edk2Path(object):
         instantiated. If using the same Workspace root and packages path, it is
         suggested that only a single Edk2Path instance is instantiated and
         passed to any consumers.
-
-    There are two OS environment variables that modify the behavior of this class with
-    respect to nested package checking:
-        PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES - converts errors about nested
-            packages to warnings.
-        PYTOOL_IGNORE_KNOWN_BAD_NESTED_PACKAGES - contains a comma-delimited list of
-            known bad packages. If a package matching a known bad package from the
-            list is encountered, an info-level message will be printed and the nested
-            package check will be skipped.
-
     """
 
     def __init__(self, ws: str, package_path_list: Iterable[str],
@@ -120,60 +110,18 @@ class Edk2Path(object):
             package_path_packages[package_path] = \
                 [p.parent for p in package_path.glob('**/*.dec')]
 
-        # Note: The ability to ignore this function raising an exception on
-        #       nested packages is temporary. Do not plan on this variable
-        #       being available long-term and try to resolve the nested
-        #       packages problem right away.
-        #
-        # Removal is tracked in the following GitHub issue:
-        # https://github.com/tianocore/edk2-pytool-library/issues/200
-        ignore_nested_packages = False
-        if "PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES" in os.environ and \
-            os.environ["PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES"].strip().lower() == \
-                "true":
-            ignore_nested_packages = True
-
-        if "PYTOOL_IGNORE_KNOWN_BAD_NESTED_PACKAGES" in os.environ:
-            pkgs_to_ignore = os.environ["PYTOOL_IGNORE_KNOWN_BAD_NESTED_PACKAGES"].split(",")
-        else:
-            pkgs_to_ignore = []
-
         for package_path, packages in package_path_packages.items():
-            packages_to_check = []
-            for package in packages:
-                if any(x in str(package) for x in pkgs_to_ignore):
-                    self.logger.log(
-                        logging.INFO,
-                        f"Ignoring nested package check for known-bad package "
-                        f"[{str(package)}].")
-                else:
-                    packages_to_check.append(package)
-            for i, package in enumerate(packages_to_check):
-                for j in range(i + 1, len(packages_to_check)):
-                    comp_package = packages_to_check[j]
+            for i, package in enumerate(packages):
+                for j in range(i + 1, len(packages)):
+                    comp_package = packages[j]
                     if (package.is_relative_to(comp_package)
                             or comp_package.is_relative_to(package)):
-                        if ignore_nested_packages:
-                            self.logger.log(
-                                logging.WARNING,
-                                f"Nested packages not allowed. The packages "
-                                f"[{str(package)}] and [{str(comp_package)}] are "
-                                f"nested.")
-                            self.logger.log(
-                                logging.WARNING,
-                                "Note 1: Nested packages are being ignored right now because the "
-                                "\"PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES\" environment variable "
-                                "is set. Do not depend on this variable long-term.")
-                            self.logger.log(
-                                logging.WARNING,
-                                "Note 2: Some pytool features may not work as expected with nested packages.")
-                        else:
-                            raise Exception(
-                                f"Nested packages not allowed. The packages "
-                                f"[{str(package)}] and [{str(comp_package)}] are "
-                                f"nested. Set the \"PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES\" "
-                                f"environment variable to \"true\" as a temporary workaround "
-                                f"until you fix the packages so they are no longer nested.")
+                        self.logger.log(
+                            logging.DEBUG,
+                            f"[{str(package)}] and [{str(comp_package)}] are nested. Nested packages are not allowed "
+                            "and may result in incorrect converions from absolute path to edk2 package path relative "
+                            "paths."
+                        )
 
     @property
     def WorkspacePath(self):

--- a/tests.unit/test_path_utilities.py
+++ b/tests.unit/test_path_utilities.py
@@ -7,6 +7,7 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 
+import logging
 import os
 import shutil
 import sys
@@ -1010,35 +1011,11 @@ class PathUtilitiesTest(unittest.TestCase):
         self._make_edk2_package_helper(folder_pp2_abs, pp2_name)
 
         # Nested packages should raise an exception by default
-        self.assertRaises(Exception, Edk2Path, folder_ws_abs, [folder_pp1_abs])
-        self.assertRaises(Exception, Edk2Path, folder_ws_abs, [folder_pp1_abs, folder_pp2_abs])
+        with self.assertLogs(logger="Edk2Path", level=logging.DEBUG) as logs:
+            Edk2Path(folder_ws_abs, [folder_pp1_abs])
+            Edk2Path(folder_ws_abs, [folder_pp1_abs, folder_pp2_abs])
+            self.assertEqual(len(logs.records), 2)
 
-        # Nested packages should no longer raise an exception
-        # Note: These tests can be removed when support for
-        #       PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES is removed.
-        os.environ["PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES"] = "true"
-        Edk2Path(folder_ws_abs, [folder_pp1_abs])
-        Edk2Path(folder_ws_abs, [folder_pp1_abs, folder_pp2_abs])
-
-        # Remove the environment variable now that the test above is complete
-        os.environ.pop("PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES")
-
-        # Nested packages should no longer raise an exception if explicitly
-        # marked as known-bad.
-        os.environ["PYTOOL_IGNORE_KNOWN_BAD_NESTED_PACKAGES"] = "SomeOtherPkg,PPTestPkg1"
-        Edk2Path(folder_ws_abs, [folder_pp1_abs])
-        Edk2Path(folder_ws_abs, [folder_pp1_abs, folder_pp2_abs])
-
-        os.environ["PYTOOL_IGNORE_KNOWN_BAD_NESTED_PACKAGES"] = "SomeOtherPkg,PPTestPkg2"
-        Edk2Path(folder_ws_abs, [folder_pp1_abs])
-        Edk2Path(folder_ws_abs, [folder_pp1_abs, folder_pp2_abs])
-
-        os.environ["PYTOOL_IGNORE_KNOWN_BAD_NESTED_PACKAGES"] = "SomeOtherPkg,SomeOtherPkg2"
-        self.assertRaises(Exception, Edk2Path, folder_ws_abs, [folder_pp1_abs])
-        self.assertRaises(Exception, Edk2Path, folder_ws_abs, [folder_pp1_abs, folder_pp2_abs])
-
-        # Remove the environment variable now that the test above is complete
-        os.environ.pop("PYTOOL_IGNORE_KNOWN_BAD_NESTED_PACKAGES")
 
     def test_get_relative_path_when_folder_is_next_to_package(self):
         '''Test usage of GetEdk2RelativePathFromAbsolutePath when a folder containing a package is in the same


### PR DESCRIPTION
Removes Nested package exceptions from path_utilities.py in favor of a warning.  This is being done as the exception has served its purpose and those willing to update their nested packages have had a year to do so. Any nested packages will now only be a warning logged at logging.DEBUG and issues with converting from an absolute path to an edk2 package path relative path will be accepted.

A new CI Check has been added so that packages managed by that specific repository will still be checked by nested packages, but nested packages outside of the control of that specific repository will not be checked and thus not result in an exception being raised.

closes #200 