### PR TITLE
Limiting capsule install to supported versions

### DIFF
--- a/edk2toollib/windows/capsule/inf_generator.py
+++ b/edk2toollib/windows/capsule/inf_generator.py
@@ -51,9 +51,9 @@ PnpLockdown=1
 CatalogFile={Name}.cat
 
 [Manufacturer]
-%MfgName% = Firmware,NT{Arch}
+%MfgName% = Firmware,NT{Arch}.10.0...16299
 
-[Firmware.NT{Arch}]
+[Firmware.NT{Arch}.10.0...16299]
 %FirmwareDesc% = Firmware_Install,UEFI\RES_{{{EsrtGuid}}}
 
 [Firmware_Install.NT]

--- a/edk2toollib/windows/capsule/inf_generator2.py
+++ b/edk2toollib/windows/capsule/inf_generator2.py
@@ -121,7 +121,7 @@ class InfHeader(object):
             CatalogFile={self.Name}.cat
 
             [Manufacturer]
-            %MfgName% = Firmware,NT{self.Arch}
+            %MfgName% = Firmware,NT{self.Arch}.10.0...16299
 
             """)
 
@@ -284,7 +284,7 @@ class InfFirmwareSections(object):
 
         This includes any InfFirmware objects in it.
         """
-        firmwareStr = f"[Firmware.NT{self.Arch}]\n"
+        firmwareStr = f"[Firmware.NT{self.Arch}.10.0...16299]\n"
         for InfFirmware in self.Sections.values():
             firmwareStr += f"%{InfFirmware.Tag}Desc% = {InfFirmware.Tag}_Install,UEFI\\RES_{{{InfFirmware.EsrtGuid}}}\n"
         firmwareStr += "\n"

--- a/tests.unit/test_inf_generator.py
+++ b/tests.unit/test_inf_generator.py
@@ -151,9 +151,9 @@ PnpLockdown=1
 CatalogFile=TestName.cat
 
 [Manufacturer]
-%MfgName% = Firmware,NTamd64
+%MfgName% = Firmware,NTamd64.10.0...16299
 
-[Firmware.NTamd64]
+[Firmware.NTamd64.10.0...16299]
 %FirmwareDesc% = Firmware_Install,UEFI\\RES_{3cad7a0c-d35b-4b75-96b1-03a9fb07b7fc}
 
 [Firmware_Install.NT]

--- a/tests.unit/test_inf_generator2.py
+++ b/tests.unit/test_inf_generator2.py
@@ -33,7 +33,7 @@ class InfHeaderTest(unittest.TestCase):
             CatalogFile=InfTest.cat
 
             [Manufacturer]
-            %MfgName% = Firmware,NTamd64
+            %MfgName% = Firmware,NTamd64.10.0...16299
 
             """)
         self.assertEqual(ExpectedStr, str(Header))
@@ -258,7 +258,7 @@ class InfFirmwareSectionsTest(unittest.TestCase):
         Sections.AddSection(Firmware)
 
         ExpectedStr = textwrap.dedent("""\
-            [Firmware.NTamd64]
+            [Firmware.NTamd64.10.0...16299]
             %tagDesc% = tag_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
 
             [tag_Install.NT]
@@ -312,7 +312,7 @@ class InfFirmwareSectionsTest(unittest.TestCase):
         Sections.AddSection(Firmware2)
 
         ExpectedStr = textwrap.dedent("""\
-            [Firmware.NTamd64]
+            [Firmware.NTamd64.10.0...16299]
             %tag1Desc% = tag1_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
             %tag2Desc% = tag2_Install,UEFI\\RES_{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
 
@@ -482,7 +482,7 @@ class InfFileTest(unittest.TestCase):
             [Manufacturer]
             %MfgName% = Firmware,NTamd64
 
-            [Firmware.NTamd64]
+            [Firmware.NTamd64.10.0...16299]
             %tag1Desc% = tag1_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
             %tag2Desc% = tag2_Install,UEFI\\RES_{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
 
@@ -576,7 +576,7 @@ class InfFileTest(unittest.TestCase):
             [Manufacturer]
             %MfgName% = Firmware,NTamd64
 
-            [Firmware.NTamd64]
+            [Firmware.NTamd64.10.0...16299]
             %tag1Desc% = tag1_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
             %tag2Desc% = tag2_Install,UEFI\\RES_{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
 
@@ -680,7 +680,7 @@ class InfFileTest(unittest.TestCase):
             [Manufacturer]
             %MfgName% = Firmware,NTamd64
 
-            [Firmware.NTamd64]
+            [Firmware.NTamd64.10.0...16299]
             %tag1Desc% = tag1_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
             %tag2Desc% = tag2_Install,UEFI\\RES_{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
 

--- a/tests.unit/test_inf_generator2.py
+++ b/tests.unit/test_inf_generator2.py
@@ -480,7 +480,7 @@ class InfFileTest(unittest.TestCase):
             CatalogFile=CapsuleName.cat
 
             [Manufacturer]
-            %MfgName% = Firmware,NTamd64
+            %MfgName% = Firmware,NTamd64.10.0...16299
 
             [Firmware.NTamd64.10.0...16299]
             %tag1Desc% = tag1_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
@@ -574,7 +574,7 @@ class InfFileTest(unittest.TestCase):
             CatalogFile=CapsuleName.cat
 
             [Manufacturer]
-            %MfgName% = Firmware,NTamd64
+            %MfgName% = Firmware,NTamd64.10.0...16299
 
             [Firmware.NTamd64.10.0...16299]
             %tag1Desc% = tag1_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
@@ -678,7 +678,7 @@ class InfFileTest(unittest.TestCase):
             CatalogFile=CapsuleName.cat
 
             [Manufacturer]
-            %MfgName% = Firmware,NTamd64
+            %MfgName% = Firmware,NTamd64.10.0...16299
 
             [Firmware.NTamd64.10.0...16299]
             %tag1Desc% = tag1_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}


### PR DESCRIPTION
The inf generators generate capsules with:
```inf
[DestinationDirs]
DefaultDestDir = 13
```
The syntax 'DIRID 13' was introduced in OS version 10.0.16299, but DDInstall sections utilizing the syntax will install on earlier OS versions. Those DDInstall sections should be restricted to only install on 10.0.16299 or higher using a TargetOSVersion decoration.

See [Combining platform extensions with operating system versions](https://learn.microsoft.com/en-us/windows-hardware/drivers/install/combining-platform-extensions-with-operating-system-versions)

Tested before and after with `infverif.exe`
