### PR TITLE
gitignore_parser.py: Multiple Updates

### DIFF
--- a/edk2toollib/gitignore_parser.py
+++ b/edk2toollib/gitignore_parser.py
@@ -262,6 +262,7 @@ def fnmatch_pathname_to_regex(
 
 def _normalize_path(path: Union[str, Path]) -> Path:
     """Normalize a path without resolving symlinks.
+
     This is equivalent to `Path.resolve()` except that it does not resolve symlinks.
     Note that this simplifies paths by removing double slashes, `..`, `.` etc. like
     `Path.resolve()` does.

--- a/edk2toollib/gitignore_parser.py
+++ b/edk2toollib/gitignore_parser.py
@@ -181,6 +181,8 @@ class IgnoreRule(collections.namedtuple('IgnoreRule_', IGNORE_RULE_FIELDS)):
             rel_path = str(_normalize_path(abs_path).relative_to(self.base_path))
         else:
             rel_path = str(_normalize_path(abs_path))
+
+        rel_path += " " * _count_trailing_whitespace(abs_path)
         # Path() strips the trailing slash, so we need to preserve it
         # in case of directory-only negation
         if self.negation and isinstance(abs_path, str) and abs_path[-1] == '/':
@@ -270,3 +272,11 @@ def _normalize_path(path: Union[str, Path]) -> Path:
     `Path.resolve()` does.
     """
     return Path(abspath(path))
+
+def _count_trailing_whitespace(text: str):
+    count = 0
+    for char in reversed(str(text)):
+        if char.isspace():
+            count += 1
+        else:
+            return count

--- a/edk2toollib/gitignore_parser.py
+++ b/edk2toollib/gitignore_parser.py
@@ -5,6 +5,7 @@
 import collections
 import os
 import re
+import sys
 from os.path import abspath, dirname
 from pathlib import Path
 from typing import Union
@@ -182,7 +183,8 @@ class IgnoreRule(collections.namedtuple('IgnoreRule_', IGNORE_RULE_FIELDS)):
         else:
             rel_path = str(_normalize_path(abs_path))
 
-        rel_path += " " * _count_trailing_whitespace(abs_path)
+        if sys.platform.startswith('win'):
+            rel_path += " " * _count_trailing_whitespace(abs_path)
         # Path() strips the trailing slash, so we need to preserve it
         # in case of directory-only negation
         if self.negation and isinstance(abs_path, str) and abs_path[-1] == '/':
@@ -279,4 +281,5 @@ def _count_trailing_whitespace(text: str):
         if char.isspace():
             count += 1
         else:
-            return count
+            break
+    return count

--- a/tests.unit/parsers/test_gitingore_parser.py
+++ b/tests.unit/parsers/test_gitingore_parser.py
@@ -17,6 +17,7 @@ from pytest import skip
 
 
 def BuildGitIgnore(root):
+    """Builds a .gitignore file in the root directory."""
     path = os.path.join(root, ".gitignore")
     with open(path, "w") as gitignore:
         gitignore.write("/Build/\n")
@@ -43,11 +44,12 @@ def BuildGitIgnore(root):
 
 
 class GitIgnoreParserTest(unittest.TestCase):
-
+    """Tests for the gitignore parser."""
     def test_gitignoreparser_filter(self):
-        '''Ensure the gitignore parser filters files and folders correctly per
-        what is specified in the parsed .gitignore file.
-        '''
+        """Ensure the gitignore parser filters files and folders correctly.
+
+        This is per what is specified in the parsed .gitignore file.
+        """
         with tempfile.TemporaryDirectory() as root:
             root = Path(root).resolve()
             gitignore_path = BuildGitIgnore(root)
@@ -137,7 +139,7 @@ class GitIgnoreParserTest(unittest.TestCase):
             self.assertTrue(rule_tester(root / 'log0A.txt'))
 
     def test_rule_from_pattern(self):
-
+        """Tests general expected functionality of rule_from_pattern."""
         # Test bad basepath
         self.assertRaises(ValueError, gitignore_parser.rule_from_pattern, "", "Test")
 
@@ -165,7 +167,7 @@ def test_ignore_no_extensions(tmp_path):
         assert rule_tester(root / "bins" / "run_me") is True
 
 def test_pound_in_filename(tmp_path):
-    """Tests that a # symbol is escaped if prefixed with a \\."""
+    r"""Tests that a # symbol is escaped if prefixed with a \\."""
     root = tmp_path.resolve()
     gitignore_path = root / ".gitignore"
 
@@ -179,6 +181,7 @@ def test_pound_in_filename(tmp_path):
     assert rule_tester(root / "#file.txt") is True
 
 def test_test_trailingspace(tmp_path):
+    """Tests that trailing spaces are not ignored."""
     root = tmp_path.resolve()
     gitignore_path = root / ".gitignore"
 
@@ -223,6 +226,7 @@ def test_slash_in_range_does_not_match_dirs(tmp_path):
     assert rule_tester('/home/tmp/abcXYZdef') is False
 
 def test_incomplete_filename(tmp_path):
+    """Tests that an incomplete filename is not matched."""
     root = tmp_path.resolve()
     gitignore_path = root / ".gitignore"
 
@@ -239,6 +243,7 @@ def test_incomplete_filename(tmp_path):
     assert rule_tester('/home/tmp/dir/o.pyc') is False
 
 def test_double_asterisks(tmp_path):
+    """Test that double astricks match any number of directories."""
     root = tmp_path.resolve()
     gitignore_path = root / ".gitignore"
 
@@ -252,6 +257,7 @@ def test_double_asterisks(tmp_path):
     assert rule_tester('/home/tmp/foo/BarBar') is False
 
 def test_double_asterisk_without_slashes_handled_like_single_asterisk(tmp_path):
+    """Test that a double asterisk without slashes is treated like a single asterisk."""
     root = tmp_path.resolve()
     gitignore_path = root / ".gitignore"
 
@@ -269,6 +275,7 @@ def test_double_asterisk_without_slashes_handled_like_single_asterisk(tmp_path):
     assert rule_tester('/home/tmp//a/bb/XX/cc/d') is False
 
 def test_more_asterisks_handled_like_single_asterisk(tmp_path):
+    """Test that multiple astricks in a row are treated as a single astrick."""
     root = tmp_path.resolve()
     gitignore_path = root / ".gitignore"
 

--- a/tests.unit/parsers/test_gitingore_parser.py
+++ b/tests.unit/parsers/test_gitingore_parser.py
@@ -243,7 +243,7 @@ def test_incomplete_filename(tmp_path):
     assert rule_tester('/home/tmp/dir/o.pyc') is False
 
 def test_double_asterisks(tmp_path):
-    """Test that double astricks match any number of directories."""
+    """Test that double asterisk match any number of directories."""
     root = tmp_path.resolve()
     gitignore_path = root / ".gitignore"
 
@@ -275,7 +275,7 @@ def test_double_asterisk_without_slashes_handled_like_single_asterisk(tmp_path):
     assert rule_tester('/home/tmp//a/bb/XX/cc/d') is False
 
 def test_more_asterisks_handled_like_single_asterisk(tmp_path):
-    """Test that multiple astricks in a row are treated as a single astrick."""
+    """Test that multiple asterisk in a row are treated as a single astrick."""
     root = tmp_path.resolve()
     gitignore_path = root / ".gitignore"
 

--- a/tests.unit/parsers/test_gitingore_parser.py
+++ b/tests.unit/parsers/test_gitingore_parser.py
@@ -296,7 +296,9 @@ def test_symlink_to_another_directory():
     This test ensures that the issue is now fixed.
     """
     with tempfile.TemporaryDirectory() as project_dir, tempfile.TemporaryDirectory() as another_dir:
-        gitignore_path = Path(project_dir, ".gitignore")
+        project_dir = Path(project_dir).resolve()
+        another_dir = Path(another_dir).resolve()
+        gitignore_path = project_dir / ".gitignore"
 
         with open(gitignore_path, 'w') as f:
             f.write('link\n')
@@ -304,8 +306,8 @@ def test_symlink_to_another_directory():
         rule_tester = gitignore_parser.parse_gitignore_file(gitignore_path, base_dir=project_dir)
 
         # Create a symlink to another directory.
-        link = Path(project_dir, 'link')
-        target = Path(another_dir, 'target')
+        link = project_dir / 'link'
+        target = another_dir / 'target'
         try:
             link.symlink_to(target)
         except OSError: # Missing permissions to do a symlink

--- a/tests.unit/parsers/test_gitingore_parser.py
+++ b/tests.unit/parsers/test_gitingore_parser.py
@@ -310,7 +310,7 @@ def test_symlink_to_another_directory():
         target = Path(another_dir, 'target')
         try:
             link.symlink_to(target)
-        except OSError: # Missing permisisons to do a symlink
+        except OSError: # Missing permissions to do a symlink
             return
 
         # Check the intended behavior according to

--- a/tests.unit/parsers/test_gitingore_parser.py
+++ b/tests.unit/parsers/test_gitingore_parser.py
@@ -13,6 +13,7 @@ import unittest
 from pathlib import Path
 
 import edk2toollib.gitignore_parser as gitignore_parser
+from pytest import skip
 
 
 def BuildGitIgnore(root):
@@ -311,7 +312,7 @@ def test_symlink_to_another_directory():
         try:
             link.symlink_to(target)
         except OSError: # Missing permissions to do a symlink
-            return
+            skip("Current user does not have permissions to perform symlink.")
 
         # Check the intended behavior according to
         # https://git-scm.com/docs/gitignore#_notes:


### PR DESCRIPTION
This squash commit merges in changes from mherrmann/gitignore_parser for the following commits:

7956d03: remove unused variable whitespace_re
ffbfd79: remove regex flags m, s
d45a085: Fix pattern with slash in range
1040aa5: Fix pattern with leading exclamation marks
cdf80b7: Fix lack of implicit anchoring of patterns to direcotry separators
cdf80b7: Fix multi-astericks that fall outside of the special cases
6abc776: Fix "a/**/b" matching "a/bb"
721f804: do not resolve symlinks

This is specifically necessary for **721f804: do not resolve symlinks** which was causing the GuidCheck plugin to fail for Edk2 as it has a symbolic link: https://github.com/tianocore/edk2/blob/master/EmulatorPkg/Unix/Host/X11IncludeHack