### PR TITLE
Corrected Logger case to logger in error condition

### DIFF
--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -108,11 +108,11 @@ class Edk2Path(object):
         if "PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES" in os.environ:
             warning = "PYTOOL_TEMPORARILY_IGNORE_NESTED_EDK_PACKAGES is no longer used by edk2-pytool-library, but is "\
                       "detected in your environment. Please remove this environment variable."
-            self.Logger.log(logging.WARNING, warning)
+            self.logger.log(logging.WARNING, warning)
         if "PYTOOL_IGNORE_KNOWN_BAD_NESTED_PACKAGES" == os.environ:
             warning = "PYTOOL_IGNORE_KNOWN_BAD_NESTED_PACKAGES is no longer used by edk2-pytool-library, but is " \
                       "detected in your environment. Please remove this environment variable."
-            self.Logger.log(logging.WARNING, warning)
+            self.logger.log(logging.WARNING, warning)
 
         package_path_packages = {}
         for package_path in self._package_path_list:


### PR DESCRIPTION
In a less used conditional case, self.Logger was referenced, whereas in the rest of the file self.logger is used. Resulted in an exception.

  File "Lib\site-packages\edk2toollib\uefi\edk2\path_utilities.py", line 111, in __init__
    self.Logger.log(logging.WARNING, warning)
    ^^^^^^^^^^^
AttributeError: 'Edk2Path' object has no attribute 'Logger'. Did you mean: 'logger'?