### PR TITLE
utility_functions: Add LongPath support to RemoveTree

### DIFF
--- a/tests.unit/test_utility_functions.py
+++ b/tests.unit/test_utility_functions.py
@@ -11,7 +11,6 @@ import io
 import os
 import sys
 import unittest
-import winreg
 
 import edk2toollib.utility_functions as utilities
 import pytest
@@ -283,6 +282,8 @@ class TestRemoveTree:
     pytest.mark.skipif(not sys.platform.startswith('win'), reason="Long Paths are only an issue on Windows")
     def test_long_path_remove_tree(self, tmp_path):
         """Tests RemoveTree's ability to remove a directory on a Windows System with LongPaths Disabled."""
+        import winreg
+
         sub_key = r"SYSTEM\CurrentControlSet\Control\FileSystem"
         value_name = "LongPathsEnabled"
 

--- a/tests.unit/test_utility_functions.py
+++ b/tests.unit/test_utility_functions.py
@@ -15,8 +15,6 @@ import unittest
 import edk2toollib.utility_functions as utilities
 import pytest
 
-if sys.platform.startswith('win'):
-    import winreg
 
 class DesiredClass():
     def __str__(self):
@@ -281,9 +279,10 @@ class ExportCTypeArrayTest(unittest.TestCase):
 
 class TestRemoveTree:
     """Tests the RemoveTree function."""
-    pytest.mark.skipif(not sys.platform.startswith('win'), reason="Long Paths are only an issue on Windows")
+    @pytest.mark.skipif(not sys.platform.startswith('win'), reason="Long Paths are only an issue on Windows")
     def test_long_path_remove_tree(self, tmp_path):
         """Tests RemoveTree's ability to remove a directory on a Windows System with LongPaths Disabled."""
+        import winreg
         sub_key = r"SYSTEM\CurrentControlSet\Control\FileSystem"
         value_name = "LongPathsEnabled"
 

--- a/tests.unit/test_utility_functions.py
+++ b/tests.unit/test_utility_functions.py
@@ -7,11 +7,14 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 
-import unittest
 import io
 import os
 import sys
+import unittest
+import winreg
+
 import edk2toollib.utility_functions as utilities
+import pytest
 
 
 class DesiredClass():
@@ -67,10 +70,10 @@ class UtilityFunctionsTest(unittest.TestCase):
 
 
 class HexdumpTest(unittest.TestCase):
-    """Tests hexdump"""
+    """Tests hexdump."""
 
     def test_hexdump_basic_usage(self):
-        """Basic Usage Test"""
+        """Basic Usage Test."""
         test = b"Hello UEFI!"
         output = io.StringIO()
 
@@ -80,7 +83,7 @@ class HexdumpTest(unittest.TestCase):
         self.assertEqual(expected_output, output.getvalue())
 
     def test_hexdump_basic_usage_offset_start(self):
-        """Basic Usage Test"""
+        """Basic Usage Test."""
         test = b"Hello UEFI!"
         output = io.StringIO()
 
@@ -91,8 +94,7 @@ class HexdumpTest(unittest.TestCase):
         self.assertEqual(expected_output, output.getvalue())
 
     def test_hexdump_basic_usage_16_bytes(self):
-        """Basic 16 byte Test"""
-
+        """Basic 16 byte Test."""
         test = b"0123456789abcdef"
         output = io.StringIO()
 
@@ -105,7 +107,7 @@ class HexdumpTest(unittest.TestCase):
         self.assertEqual(expected_output, output.getvalue())
 
     def test_hexdump_basic_usage_32_bytes(self):
-        """Basic 32 byte Test"""
+        """Basic 32 byte Test."""
         test = b"0123456789abcdef0123456789abcdef"
         output = io.StringIO()
 
@@ -119,7 +121,7 @@ class HexdumpTest(unittest.TestCase):
         self.assertEqual(expected_output, output.getvalue())
 
     def test_hexdump_basic_usage_33_bytes(self):
-        """Basic 32 byte Test"""
+        """Basic 32 byte Test."""
         test = b"0123456789abcdef0123456789abcdef0"
         output = io.StringIO()
 
@@ -133,7 +135,7 @@ class HexdumpTest(unittest.TestCase):
         self.assertEqual(expected_output, output.getvalue())
 
     def test_hexdump_basic_usage_32_bytes_and_line_cont(self):
-        """Basic line continuation Test"""
+        """Basic line continuation Test."""
         test = b"0123456789abcde\\0123456789abcde\\"
         output = io.StringIO()
 
@@ -146,7 +148,7 @@ class HexdumpTest(unittest.TestCase):
         self.assertEqual(expected_output, output.getvalue())
 
     def test_hexdump_basic_usage_empty(self):
-        """Ensures empty response"""
+        """Ensures empty response."""
         test = io.BytesIO(b"")
         output = io.StringIO()
         newline = '\n'
@@ -159,10 +161,10 @@ class HexdumpTest(unittest.TestCase):
 
 
 class ExportCTypeArrayTest(unittest.TestCase):
-    """Tests export_c_type_array"""
+    """Tests export_c_type_array."""
 
     def test_export_c_type_array_basic_usage(self):
-        """Basic Usage Test"""
+        """Basic Usage Test."""
         original_bytes = b"Hello UEFI!"
         length = len(original_bytes)
         test = io.BytesIO(original_bytes)
@@ -179,7 +181,7 @@ class ExportCTypeArrayTest(unittest.TestCase):
         self.assertEqual(expected_output, output.getvalue())
 
     def test_export_c_type_array_include_length_variable(self):
-        """Basic Usage Test"""
+        """Basic Usage Test."""
         original_bytes = b"Hello UEFI!"
         length = len(original_bytes)
         test = io.BytesIO(original_bytes)
@@ -197,8 +199,7 @@ class ExportCTypeArrayTest(unittest.TestCase):
         self.assertEqual(expected_output, output.getvalue())
 
     def test_export_c_type_array_16_bytes(self):
-        """Basic 16 byte Test"""
-
+        """Basic 16 byte Test."""
         original_bytes = b"0123456789abcdef"
         length = len(original_bytes)
         test = io.BytesIO(original_bytes)
@@ -215,7 +216,7 @@ class ExportCTypeArrayTest(unittest.TestCase):
         self.assertEqual(expected_output, output.getvalue())
 
     def test_export_c_type_array_32_bytes(self):
-        """Basic 32 byte Test"""
+        """Basic 32 byte Test."""
         original_bytes = b"0123456789abcdef0123456789abcdef"
         length = len(original_bytes)
         test = io.BytesIO(original_bytes)
@@ -233,7 +234,7 @@ class ExportCTypeArrayTest(unittest.TestCase):
         self.assertEqual(expected_output, output.getvalue())
 
     def test_export_c_type_array_33_bytes(self):
-        """Basic 32 byte Test"""
+        """Basic 32 byte Test."""
         original_bytes = b"0123456789abcdef0123456789abcdef0"
         length = len(original_bytes)
         test = io.BytesIO(original_bytes)
@@ -252,7 +253,7 @@ class ExportCTypeArrayTest(unittest.TestCase):
         self.assertEqual(expected_output, output.getvalue())
 
     def test_export_c_type_array_32_bytes_and_line_cont(self):
-        """Basic line continuation Test"""
+        """Basic line continuation Test."""
         original_bytes = b"0123456789abcde\\0123456789abcde\\"
         length = len(original_bytes)
         test = io.BytesIO(original_bytes)
@@ -270,12 +271,35 @@ class ExportCTypeArrayTest(unittest.TestCase):
         self.assertEqual(expected_output, output.getvalue())
 
     def test_export_c_type_array_empty(self):
-        """Ensure exception is raised if the array is length 0"""
+        """Ensure exception is raised if the array is length 0."""
         binary_data = io.BytesIO(b"")
         output = io.StringIO()
 
         with self.assertRaises(ValueError):
             utilities.export_c_type_array(binary_data, "TestVariable", output)
+
+class TestRemoveTree:
+    """Tests the RemoveTree function."""
+    pytest.mark.skipif(not sys.platform.startswith('win'), reason="Long Paths are only an issue on Windows")
+    def test_long_path_remove_tree(self, tmp_path):
+        """Tests RemoveTree's ability to remove a directory on a Windows System with LongPaths Disabled."""
+        sub_key = r"SYSTEM\CurrentControlSet\Control\FileSystem"
+        value_name = "LongPathsEnabled"
+
+        key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, sub_key)
+        value, _ = winreg.QueryValueEx(key, value_name)
+        if value == 1:
+            pytest.skip(r"Long paths are enabled. To run the test, disable long paths with the registry key located at: HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystemLongPathsEnabled")  # noqa: E501
+
+        long_path = str(tmp_path / ("a" * 250)) # A single folder cannot be longer than 260 characters.
+        assert len(str(long_path)) > 260 # Make sure the path is actually long.
+
+        # Must use the \\?\ prefix to be able to create a long path when Long Paths are disabled.
+        os.mkdir('\\\\?\\' + long_path)
+        with open('\\\\?\\' + long_path + "\\file.txt", "w") as f:
+            f.write("Hello World!")
+
+        utilities.RemoveTree(long_path)
 
 # DO NOT PUT A MAIN FUNCTION HERE
 # this test runs itself to test runpython script, which is a tad bit strange yes.

--- a/tests.unit/test_utility_functions.py
+++ b/tests.unit/test_utility_functions.py
@@ -15,6 +15,8 @@ import unittest
 import edk2toollib.utility_functions as utilities
 import pytest
 
+if sys.platform.startswith('win'):
+    import winreg
 
 class DesiredClass():
     def __str__(self):
@@ -282,8 +284,6 @@ class TestRemoveTree:
     pytest.mark.skipif(not sys.platform.startswith('win'), reason="Long Paths are only an issue on Windows")
     def test_long_path_remove_tree(self, tmp_path):
         """Tests RemoveTree's ability to remove a directory on a Windows System with LongPaths Disabled."""
-        import winreg
-
         sub_key = r"SYSTEM\CurrentControlSet\Control\FileSystem"
         value_name = "LongPathsEnabled"
 


### PR DESCRIPTION
On Windows systems with long paths disabled, the RemoveTree function fails to remove files that go over the character limit as they cannot be found. This change, on windows, prefixes the path with the '\\\\?\\' which allows for the detection of long paths, and allows for the removal of the file.

Closes #445