### PR TITLE
base_parser: Don't treat pound signs wrapped in quotes as comments

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/base_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/base_parser.py
@@ -8,6 +8,7 @@
 """Code to support parsing EDK2 files."""
 import logging
 import os
+import re
 from warnings import warn
 
 from edk2toollib.uefi.edk2 import path_utilities
@@ -794,6 +795,7 @@ class BaseParser(object):
 
 class HashFileParser(BaseParser):
     """Base class for Edk2 build files that use # for comments."""
+    COMMENT_PATTERN = re.compile(r'(?<!["\'])#(?!["\'])')
 
     def __init__(self, log):
         """Inits an empty Parser for files that use # for comments.."""
@@ -805,7 +807,7 @@ class HashFileParser(BaseParser):
         Args:
           line (str): line with a comment (#)
         """
-        return line.split('#')[0].strip()
+        return re.split(self.COMMENT_PATTERN, line)[0].strip()
 
     def ParseNewSection(self, line):
         """Parses a new section line.

--- a/tests.unit/parsers/test_hash_file_parser.py
+++ b/tests.unit/parsers/test_hash_file_parser.py
@@ -39,15 +39,15 @@ class TestBaseParser(unittest.TestCase):
         parser = HashFileParser("")
 
         lines_to_test = [
-            ("Test \t# this shouldn't show up", "Test"),
-            ("Test # test", "Test"),
-            ("MagicLib|Include/Magic \t# this shouldn't show up", "MagicLib|Include/Magic"),
-            ("MagicLib|Include/Magic # test", "MagicLib|Include/Magic"),
-            ("# this is a comment", ""),
-            ("gMyPkgTokenSpaceGuid.MyThing|'Value'|VOID*|0x10000000 # My Comment", "gMyPkgTokenSpaceGuid.MyThing|'Value'|VOID*|0x10000000"),
-            ('gMyPkgTokenSpaceGuid.MyThing|"Value"|VOID*|0x10000000 # My Comment', 'gMyPkgTokenSpaceGuid.MyThing|"Value"|VOID*|0x10000000'),
-            ('gMyPkgTokenSpaceGuid.MyThing|"#Value"|VOID*|0x10000000 # My Comment', 'gMyPkgTokenSpaceGuid.MyThing|"#Value"|VOID*|0x10000000'),
+            ("Test", "\t# this shouldn't show up"),
+            ("Test", " # test"),
+            ("MagicLib|Include/Magic", "\t# this shouldn't show up"),
+            ("MagicLib|Include/Magic", "# test"),
+            ("", "# this is a comment"),
+            ("gMyPkgTokenSpaceGuid.MyThing|'Value'|VOID*|0x10000000", " # My Comment"),
+            ('gMyPkgTokenSpaceGuid.MyThing|"Value"|VOID*|0x10000000', "# My Comment"),
+            ('gMyPkgTokenSpaceGuid.MyThing|"#Value"|VOID*|0x10000000', "# My Comment"),
         ]
 
         for line in lines_to_test:
-            self.assertEqual(parser.StripComment(line[0]), line[1])
+            self.assertEqual(parser.StripComment(line[0]+line[1]), line[0])

--- a/tests.unit/parsers/test_hash_file_parser.py
+++ b/tests.unit/parsers/test_hash_file_parser.py
@@ -8,6 +8,7 @@
 ##
 
 import unittest
+
 from edk2toollib.uefi.edk2.parsers.base_parser import HashFileParser
 
 
@@ -36,10 +37,17 @@ class TestBaseParser(unittest.TestCase):
 
     def test_strip_comment(self):
         parser = HashFileParser("")
-        lines = ["Test", "MagicLib|Include/Magic", ""]
-        comments = ["\t#this shouldn't show up", " # test", ""]
-        for line in lines:
-            for comment in comments:
-                test_line = line + comment
-                result = parser.StripComment(test_line)
-                self.assertEqual(result, line)
+
+        lines_to_test = [
+            ("Test \t# this shouldn't show up", "Test"),
+            ("Test # test", "Test"),
+            ("MagicLib|Include/Magic \t# this shouldn't show up", "MagicLib|Include/Magic"),
+            ("MagicLib|Include/Magic # test", "MagicLib|Include/Magic"),
+            ("# this is a comment", ""),
+            ("gMyPkgTokenSpaceGuid.MyThing|'Value'|VOID*|0x10000000 # My Comment", "gMyPkgTokenSpaceGuid.MyThing|'Value'|VOID*|0x10000000"),
+            ('gMyPkgTokenSpaceGuid.MyThing|"Value"|VOID*|0x10000000 # My Comment', 'gMyPkgTokenSpaceGuid.MyThing|"Value"|VOID*|0x10000000'),
+            ('gMyPkgTokenSpaceGuid.MyThing|"#Value"|VOID*|0x10000000 # My Comment', 'gMyPkgTokenSpaceGuid.MyThing|"#Value"|VOID*|0x10000000'),
+        ]
+
+        for line in lines_to_test:
+            self.assertEqual(parser.StripComment(line[0]), line[1])


### PR DESCRIPTION
Edk2 supports pound signs in pcd definitions, however the simple edk2 config file parser provided by edk2-pytool-library did not support this. This commit updates the removal of comments to only remove pound signs (and everything after) if the pound sign is not wrapped in quotes.