### PR TITLE
base_parser: Update StripComment to consider quote groupings

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/base_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/base_parser.py
@@ -811,9 +811,10 @@ class HashFileParser(BaseParser):
         result = []
         inside_quotes = False
         quote_char = None
+        escaped = False
 
         for char in line:
-            if char in ('"', "'"):
+            if char in ('"', "'") and not escaped:
                 if not inside_quotes:
                     inside_quotes = True
                     quote_char = char
@@ -822,6 +823,10 @@ class HashFileParser(BaseParser):
                     quote_char = None
             elif char == '#' and not inside_quotes:
                 break
+            elif char == '\\' and not escaped:
+                escaped = True
+            else:
+                escaped = False
 
             result.append(char)
 

--- a/edk2toollib/uefi/edk2/parsers/base_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/base_parser.py
@@ -807,7 +807,27 @@ class HashFileParser(BaseParser):
         Args:
           line (str): line with a comment (#)
         """
-        return re.split(self.COMMENT_PATTERN, line)[0].strip()
+        if "#" not in line:
+            return line.strip()
+
+        result = []
+        inside_quotes = False
+        quote_char = None
+
+        for char in line:
+            if char in ('"', "'"):
+                if not inside_quotes:
+                    inside_quotes = True
+                    quote_char = char
+                elif char == quote_char:
+                    inside_quotes = False
+                    quote_char = None
+            elif char == '#' and not inside_quotes:
+                break
+
+            result.append(char)
+
+        return ''.join(result).rstrip()
 
     def ParseNewSection(self, line):
         """Parses a new section line.

--- a/edk2toollib/uefi/edk2/parsers/base_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/base_parser.py
@@ -8,7 +8,6 @@
 """Code to support parsing EDK2 files."""
 import logging
 import os
-import re
 from warnings import warn
 
 from edk2toollib.uefi.edk2 import path_utilities
@@ -795,7 +794,6 @@ class BaseParser(object):
 
 class HashFileParser(BaseParser):
     """Base class for Edk2 build files that use # for comments."""
-    COMMENT_PATTERN = re.compile(r'(?<!["\'])#(?!["\'])')
 
     def __init__(self, log):
         """Inits an empty Parser for files that use # for comments.."""

--- a/tests.unit/parsers/test_hash_file_parser.py
+++ b/tests.unit/parsers/test_hash_file_parser.py
@@ -47,6 +47,10 @@ class TestBaseParser(unittest.TestCase):
             ("gMyPkgTokenSpaceGuid.MyThing|'Value'|VOID*|0x10000000", " # My Comment"),
             ('gMyPkgTokenSpaceGuid.MyThing|"Value"|VOID*|0x10000000', "# My Comment"),
             ('gMyPkgTokenSpaceGuid.MyThing|"#Value"|VOID*|0x10000000', "# My Comment"),
+            ('file_data = "DEFINE TEST DEFINE = \"DEFINE_VALUE\""', ' # "Test String" # Test String'),
+            ("file_data = 'DEFINE TEST DEFINE = \"DEFINE_VALUE\"'", ' # "Test String" # Test String'),
+            ('file_data = "DEFINE TEST DEFINE = \"DEFINE_VALUE\" \' more to check \'"', ' # "Test String" # Test String'),
+            ('file_data = \'DEFINE\" # TEMP \" UPDATE \'', "# Found a quote")
         ]
 
         for line in lines_to_test:

--- a/tests.unit/parsers/test_hash_file_parser.py
+++ b/tests.unit/parsers/test_hash_file_parser.py
@@ -50,7 +50,10 @@ class TestBaseParser(unittest.TestCase):
             ('file_data = "DEFINE TEST DEFINE = \"DEFINE_VALUE\""', ' # "Test String" # Test String'),
             ("file_data = 'DEFINE TEST DEFINE = \"DEFINE_VALUE\"'", ' # "Test String" # Test String'),
             ('file_data = "DEFINE TEST DEFINE = \"DEFINE_VALUE\" \' more to check \'"', ' # "Test String" # Test String'),
-            ('file_data = \'DEFINE\" # TEMP \" UPDATE \'', "# Found a quote")
+            ('file_data = \'DEFINE\" # TEMP \" UPDATE \'', "# Found a quote"),
+            (r'test = \"', ' # Temp \"'),
+            ('file_data = "DEFINE TEST DEFINE = \"DEFINE\\"_VALUE\""', ' # "Test String" # Test String'),
+            ('file_data = "DEFINE TEST DEFINE = \"DEFINE\\\'_VALUE\""', ' # "Test String" # Test String'),
         ]
 
         for line in lines_to_test:

--- a/tests.unit/parsers/test_hash_file_parser.py
+++ b/tests.unit/parsers/test_hash_file_parser.py
@@ -51,7 +51,7 @@ class TestBaseParser(unittest.TestCase):
             ("file_data = 'DEFINE TEST DEFINE = \"DEFINE_VALUE\"'", ' # "Test String" # Test String'),
             ('file_data = "DEFINE TEST DEFINE = \"DEFINE_VALUE\" \' more to check \'"', ' # "Test String" # Test String'),
             ('file_data = \'DEFINE\" # TEMP \" UPDATE \'', "# Found a quote"),
-            (r'test = \"', ' # Temp \"'),
+            (r'test = \"', r' # Temp \"'),
             ('file_data = "DEFINE TEST DEFINE = \"DEFINE\\"_VALUE\""', ' # "Test String" # Test String'),
             ('file_data = "DEFINE TEST DEFINE = \"DEFINE\\\'_VALUE\""', ' # "Test String" # Test String'),
         ]


### PR DESCRIPTION
Previous update to StripComment would ignore any pound signs that were surrounded by quotes, but did not consider if the sign was inside two quotes or between two sets of two quotes (i.e. `" # "` vs `" 1 " # " 2 "`). This commit updates StripComment to check this scenario and not strip if the pound sign is inside two quotes.

This additionally adds support for ignoring escaped quotes.

