### PR TITLE
table parsers: Use closest package path relative path

### DIFF
--- a/edk2toollib/database/tables/instanced_inf_table.py
+++ b/edk2toollib/database/tables/instanced_inf_table.py
@@ -169,6 +169,11 @@ class InstancedInfTable(TableGenerator):
             if arch not in self.arch:
                 continue
 
+            # Developers can set an inf path to be relative to any package path. Convert it to be the closest
+            # package path relative path to the INF, which is done by `GetEdk2RelativePathFromAbsolutePath`
+            inf = self.pathobj.GetAbsolutePathOnThisSystemFromEdk2RelativePath(inf)
+            inf = self.pathobj.GetEdk2RelativePathFromAbsolutePath(inf)
+
             logging.debug(f"Parsing Component: [{arch}][{inf}]")
             infp = InfP().SetEdk2Path(self.pathobj)
             infp.ParseFile(inf)
@@ -346,5 +351,8 @@ class InstancedInfTable(TableGenerator):
         for library_instance in library_instance_list:
             infp = self.inf(library_instance)
             if module.lower() in [phase.lower() for phase in infp.SupportedPhases]:
+                # Ensure the returned path is relative to the closest package path
+                library_instance = self.pathobj.GetAbsolutePathOnThisSystemFromEdk2RelativePath(library_instance)
+                library_instance = self.pathobj.GetEdk2RelativePathFromAbsolutePath(library_instance)
                 return library_instance
         return None

--- a/tests.unit/database/test_instanced_fv_table.py
+++ b/tests.unit/database/test_instanced_fv_table.py
@@ -92,7 +92,7 @@ def test_non_closest_inf_path(empty_tree: Tree):
     dsc = empty_tree.create_dsc()
     fdf = empty_tree.create_fdf(
         fv_testfv = [
-            "INF Common/Subfolder/Drivers/TestDriver1.inf",
+            "INF Common/SubFolder/Drivers/TestDriver1.inf",
         ]
     )
 

--- a/tests.unit/database/test_instanced_fv_table.py
+++ b/tests.unit/database/test_instanced_fv_table.py
@@ -30,7 +30,8 @@ def test_valid_fdf(empty_tree: Tree):  # noqa: F811
     comp1 = empty_tree.create_component("TestDriver1", "DXE_DRIVER")
     comp2 = empty_tree.create_component("TestDriver2", "DXE_DRIVER")
     comp3 = empty_tree.create_component("TestDriver3", "DXE_DRIVER")
-    comp4 = str(Path('TestPkg','Extra Drivers','TestDriver4.inf'))
+    Path(empty_tree.package / "Extra Drivers").mkdir()
+    Path(empty_tree.package / "Extra Drivers" / "TestDriver4.inf").touch()
     comp5 = empty_tree.create_component("TestDriver5", "DXE_DRIVER")
 
     dsc = empty_tree.create_dsc()
@@ -38,11 +39,11 @@ def test_valid_fdf(empty_tree: Tree):  # noqa: F811
     # Write the FDF; includes a "infformat" FV used to test
     # All the different ways an INF can be defined in the FDF
     fdf = empty_tree.create_fdf(
-        fv_infformat = [
+        fv_testfv = [
             f"INF  {comp1}", # PP relative
             f'INF  {str(empty_tree.ws / comp2)}', # Absolute
             f'INF  RuleOverride=RESET_VECTOR {comp3}', # RuleOverride
-            f'INF  {comp4}', # Space in path
+            'INF  TestPkg/Extra Drivers/TestDriver4.inf', # Space in path
             f'INF  ruleoverride = RESET_VECTOR {comp5}', # RuleOverride lowercase & spaces'
         ]
     )
@@ -54,14 +55,14 @@ def test_valid_fdf(empty_tree: Tree):  # noqa: F811
     }
     db.parse(env)
 
-    rows = db.connection.execute("SELECT key2 FROM junction where key1 == 'infformat'").fetchall()
+    rows = db.connection.execute("SELECT key2 FROM junction where key1 == 'testfv'").fetchall()
 
     assert len(rows) == 5
     assert sorted(rows) == sorted([
         (Path(comp1).as_posix(),),
         (Path(comp2).as_posix(),),
         (Path(comp3).as_posix(),),
-        (Path(comp4).as_posix(),),
+        ('TestPkg/Extra Drivers/TestDriver4.inf',),
         (Path(comp5).as_posix(),),
     ])
 

--- a/tests.unit/database/test_instanced_fv_table.py
+++ b/tests.unit/database/test_instanced_fv_table.py
@@ -103,7 +103,7 @@ def test_non_closest_inf_path(empty_tree: Tree):
     # Create a subfolder of common folder, which is also a package path
     sub_folder = common_folder / "SubFolder"
     sub_folder.mkdir()
-    edk2path = Edk2Path(str(empty_tree.ws), ["Common", "Common/SubFolder"])
+    edk2path = Edk2Path(str(empty_tree.ws), ["Common", str(sub_folder)])
 
     # Make the INF we want to make sure we get the closest match of
     (sub_folder / "Drivers").mkdir()


### PR DESCRIPTION
INF paths in the DSC and FDF can be defined as an absolute path, relative to the workspace, or relative to any package path. To ensure consistency with paths, this change converts any provided path to be relative to the closest package path. This simplifies queries that typically use the `path` column for filtering, or `join` commands.

That is to say, if there are two package paths: `Common/`, `Common/Special/`, a path can be relative to either of these packages paths. So both `Special/Files/MyFile.c` and `Files/MyFile.c` are acceptable. However when inserting into the database, we now ensure that the closest package path relative path is used. In the above example, that means `Files/MyFile.c`.