### PR TITLE
Update deploy-pages to 4.0.1

### DIFF
--- a/.github/workflows/doc-release.yml
+++ b/.github/workflows/doc-release.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
     - name: Deploy Github Pages Site
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@v4.0.1
       with:
         token: ${{ github.token }}
         artifact_name: "github-pages"


### PR DESCRIPTION
Updates deploy-pages github action to 4.0.1 which, from deploy-pages should resolve the build error being seen is [ #732 ](https://github.com/tianocore/edk2-pytool-extensions/issues/732)