### PR TITLE
instanced_inf_table: include NULL libs

### DIFF
--- a/edk2toollib/database/tables/instanced_inf_table.py
+++ b/edk2toollib/database/tables/instanced_inf_table.py
@@ -230,8 +230,6 @@ class InstancedInfTable(TableGenerator):
                 library_class_list.append("NULL")
 
             for null_lib in self._get_null_lib_instances(scope, library_dict):
-                if null_lib == inf:
-                    continue
                 library_instance_list.append(null_lib)
                 library_class_list.append("NULL")
 

--- a/edk2toollib/database/tables/instanced_inf_table.py
+++ b/edk2toollib/database/tables/instanced_inf_table.py
@@ -228,6 +228,10 @@ class InstancedInfTable(TableGenerator):
             library_instance_list.append(null_lib)
             library_class_list.append("NULL")
 
+        for null_lib in self._get_null_lib_instances(inf, scope, library_dict):
+            library_instance_list.append(null_lib)
+            library_class_list.append("NULL")
+
         #
         # 3. Recursively parse used libraries
         #
@@ -355,3 +359,39 @@ class InstancedInfTable(TableGenerator):
                 library_instance = self.pathobj.GetEdk2RelativePathFromAbsolutePath(library_instance)
                 return library_instance
         return None
+
+    def _get_null_lib_instances(
+        self,
+        inf: str,
+        scope: str,
+        library_dict: dict,
+    ) -> list:
+        """Returns all null libraries for a given scope.
+
+        Args:
+            inf (str): The INF file to ignore null libraries for.
+            scope (str): The scope to search for null libraries.
+            library_dict (dict): The dictionary of libraries to search through.
+
+        Returns:
+            list: A list of null libraries for the given scope.
+        """
+        arch, module = tuple(scope.split("."))
+        null_libs = []
+
+        lookup = f'{arch}.{module}.null'
+        null_libs.extend(library_dict.get(lookup, []))
+
+        lookup = f'common.{module}.null'
+        null_libs.extend(library_dict.get(lookup, []))
+
+        lookup = f'{arch}.null'
+        null_libs.extend(library_dict.get(lookup, []))
+
+        lookup = 'common.null'
+        null_libs.extend(library_dict.get(lookup, []))
+
+        if inf in null_libs:
+            null_libs.remove(inf)
+
+        return null_libs

--- a/edk2toollib/database/tables/instanced_inf_table.py
+++ b/edk2toollib/database/tables/instanced_inf_table.py
@@ -222,17 +222,18 @@ class InstancedInfTable(TableGenerator):
             library_class_list.append(lib)
 
         #
-        # 2. Append all NULL library instances
+        # 2. Append all NULL library instances if parsing the component.
         #
-        for null_lib in override_dict["NULL"]:
-            library_instance_list.append(null_lib)
-            library_class_list.append("NULL")
+        if inf == component:
+            for null_lib in override_dict["NULL"]:
+                library_instance_list.append(null_lib)
+                library_class_list.append("NULL")
 
-        for null_lib in self._get_null_lib_instances(scope, library_dict):
-            if null_lib == inf:
-                continue
-            library_instance_list.append(null_lib)
-            library_class_list.append("NULL")
+            for null_lib in self._get_null_lib_instances(scope, library_dict):
+                if null_lib == inf:
+                    continue
+                library_instance_list.append(null_lib)
+                library_class_list.append("NULL")
 
         #
         # 3. Recursively parse used libraries

--- a/edk2toollib/database/tables/instanced_inf_table.py
+++ b/edk2toollib/database/tables/instanced_inf_table.py
@@ -228,7 +228,9 @@ class InstancedInfTable(TableGenerator):
             library_instance_list.append(null_lib)
             library_class_list.append("NULL")
 
-        for null_lib in self._get_null_lib_instances(inf, scope, library_dict):
+        for null_lib in self._get_null_lib_instances(scope, library_dict):
+            if null_lib == inf:
+                continue
             library_instance_list.append(null_lib)
             library_class_list.append("NULL")
 
@@ -362,14 +364,12 @@ class InstancedInfTable(TableGenerator):
 
     def _get_null_lib_instances(
         self,
-        inf: str,
         scope: str,
         library_dict: dict,
     ) -> list:
         """Returns all null libraries for a given scope.
 
         Args:
-            inf (str): The INF file to ignore null libraries for.
             scope (str): The scope to search for null libraries.
             library_dict (dict): The dictionary of libraries to search through.
 
@@ -390,8 +390,5 @@ class InstancedInfTable(TableGenerator):
 
         lookup = 'common.null'
         null_libs.extend(library_dict.get(lookup, []))
-
-        if inf in null_libs:
-            null_libs.remove(inf)
 
         return null_libs


### PR DESCRIPTION
Adds all NULL libraries that are defined in a library classes section, to the list of libraries associated with a specific component.

ensures all NULL libraries are only associated with the component, and not libraries of that component.