### PR TITLE
upgrade markdownlint-cli

### DIFF
--- a/.github/workflows/CIRunner.yml
+++ b/.github/workflows/CIRunner.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Install npm Dependencies
       run: |
-        npm install -g markdownlint-cli@0.32.2
+        npm install -g markdownlint-cli@0.39.0
         npm install -g cspell@5.20.0
 
     - name: Run ruff

--- a/readme.md
+++ b/readme.md
@@ -25,16 +25,16 @@ and that code coverage percentage does not lower.
 Supported Versions
 
 |  Host Type         |  Toolchain    |  Status
-|  :---------------  |  :----------  |  :--------------------  |
-|  [Windows-Latest]  |  Python 3.10  |  [![ci]][_ci]           |
-|  [Windows-Latest]  |  Python 3.11  |  [![ci]][_ci]           |
-|  [Windows-Latest]  |  Python 3.12  |  [![ci]][_ci]           |
-|  [Ubuntu-Latest]   |  Python 3.10  |  [![ci]][_ci]           |
-|  [Ubuntu-Latest]   |  Python 3.11  |  [![ci]][_ci]           |
-|  [Ubuntu-Latest]   |  Python 3.12  |  [![ci]][_ci]           |
-|  [MacOS-Latest]    |  Python 3.10  |  [![coming_soon]][_ci]  |
-|  [MacOS-Latest]    |  Python 3.11  |  [![coming_soon]][_ci]  |
-|  [MacOS-Latest]    |  Python 3.12  |  [![coming_soon]][_ci]  |
+|  :---------------  |  :----------  |  :--------------------
+|  [Windows-Latest]  |  Python 3.10  |  [![ci]][_ci]
+|  [Windows-Latest]  |  Python 3.11  |  [![ci]][_ci]
+|  [Windows-Latest]  |  Python 3.12  |  [![ci]][_ci]
+|  [Ubuntu-Latest]   |  Python 3.10  |  [![ci]][_ci]
+|  [Ubuntu-Latest]   |  Python 3.11  |  [![ci]][_ci]
+|  [Ubuntu-Latest]   |  Python 3.12  |  [![ci]][_ci]
+|  [MacOS-Latest]    |  Python 3.10  |  [![coming_soon]][_ci]
+|  [MacOS-Latest]    |  Python 3.11  |  [![coming_soon]][_ci]
+|  [MacOS-Latest]    |  Python 3.12  |  [![coming_soon]][_ci]
 
 ### Current Release
 


### PR DESCRIPTION
Upgrades markdownlint-cli to 0.39.0 from 0.32.2.

The release is currently failing as the release pipeline that comes from edk2-pytool-extensions does not have a locked version of markdown lint. This upgrades markdownlint-cli to 0.39.0, which will be the locked version in edk2-pytool-extensions.