### PR TITLE
base_parser: support no spaces in conditional expression

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/base_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/base_parser.py
@@ -534,6 +534,8 @@ class BaseParser(object):
         TEXT_MODE = 0
         QUOTE_MODE = 1
         MACRO_MODE = 2
+        CONDITION_MODE = 3
+        CONDITION_CHARACTERS = ["=", ">", "<", "!"]
         token = ""
         mode = 0
         tokens = []
@@ -563,6 +565,25 @@ class BaseParser(object):
                     tokens.append(token)
                     token = ""
                     mode = TEXT_MODE
+            elif mode == CONDITION_MODE and character == "(":
+                mode = TEXT_MODE
+                if len(token) > 0:
+                    tokens.append(token)
+                    token = ""
+                tokens.append(character)
+            elif character in CONDITION_CHARACTERS and mode == CONDITION_MODE:
+                token += character
+            elif character not in CONDITION_CHARACTERS and mode == CONDITION_MODE:
+                if len(token) > 0:
+                    tokens.append(token)
+                token = character if character != " " else ''
+                mode = TEXT_MODE
+            elif character in CONDITION_CHARACTERS and mode == TEXT_MODE:
+                if len(token) > 0:
+                    tokens.append(token)
+                    token = ''
+                token = character
+                mode = CONDITION_MODE
             else:
                 token += character
         # make sure to add in the last token just in case

--- a/tests.unit/parsers/test_base_parser.py
+++ b/tests.unit/parsers/test_base_parser.py
@@ -7,11 +7,12 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 
+import os
+import tempfile
 import unittest
+
 from edk2toollib.uefi.edk2.parsers.base_parser import BaseParser
 from edk2toollib.uefi.edk2.path_utilities import Edk2Path
-import tempfile
-import os
 
 
 class TestBaseParser(unittest.TestCase):
@@ -460,14 +461,14 @@ class TestBaseParserConditionals(unittest.TestCase):
         parser.ResetParserState()
 
     def test_emulator_conditional_parens_order(self):
-        ''' Makes sure the parenthesis affect the order of expressions '''
+        '''Makes sure the parenthesis affect the order of expressions'''
         parser = BaseParser("")
         self.assertFalse(parser.EvaluateConditional('!if TRUE OR FALSE AND FALSE'))
         self.assertTrue(parser.EvaluateConditional('!if TRUE OR (FALSE AND FALSE)'))
         parser.ResetParserState()
 
     def test_emulator_conditional_not_or(self):
-        ''' Makes sure we can use the not with other operators '''
+        '''Makes sure we can use the not with other operators'''
         parser = BaseParser("")
         self.assertTrue(parser.EvaluateConditional('!if FALSE NOT OR FALSE'))
         self.assertFalse(parser.EvaluateConditional('!if TRUE NOT OR FALSE'))
@@ -475,7 +476,7 @@ class TestBaseParserConditionals(unittest.TestCase):
         self.assertFalse(parser.EvaluateConditional('!if TRUE NOT OR TRUE'))
 
     def test_emulator_conditional_not_it_all(self):
-        ''' Makes sure the parenthesis affect the order of expressions '''
+        '''Makes sure the parenthesis affect the order of expressions'''
         parser = BaseParser("")
         self.assertTrue(parser.EvaluateConditional('!if NOT FALSE OR FALSE'))
         self.assertFalse(parser.EvaluateConditional('!if NOT TRUE OR FALSE'))
@@ -489,7 +490,7 @@ class TestBaseParserConditionals(unittest.TestCase):
         parser.ResetParserState()
 
     def test_conditional_with_variable(self):
-        ''' Makes sure conversions are correct when using variables '''
+        '''Makes sure conversions are correct when using variables'''
         parser = BaseParser("")
         parser.LocalVars = {"MAX_SOCKET": '4', 'TARGET': 'DEBUG'}
 
@@ -507,6 +508,30 @@ class TestBaseParserConditionals(unittest.TestCase):
 
         self.assertTrue(parser.ProcessConditional('!if ($(TARGET) == "RELEASE") && ($(MAX_SOCKET) <= 4)'))
         self.assertFalse(parser.InActiveCode())
+        self.assertTrue(parser.ProcessConditional('!endif'))
+
+    def test_conditional_without_spaces(self):
+        parser = BaseParser("")
+        parser.LocalVars = {"MAX_SOCKET": '4', 'TARGET': 'DEBUG'}
+
+        self.assertTrue(parser.ProcessConditional('!if $(MAX_SOCKET)<=4'))
+        self.assertTrue(parser.InActiveCode())
+        self.assertTrue(parser.ProcessConditional('!endif'))
+
+        self.assertTrue(parser.ProcessConditional('!if $(MAX_SOCKET) <=4'))
+        self.assertTrue(parser.InActiveCode())
+        self.assertTrue(parser.ProcessConditional('!endif'))
+
+        self.assertTrue(parser.ProcessConditional('!if $(MAX_SOCKET)<= 4'))
+        self.assertTrue(parser.InActiveCode())
+        self.assertTrue(parser.ProcessConditional('!endif'))
+
+        self.assertTrue(parser.ProcessConditional('!if $(MAX_SOCKET)>=4'))
+        self.assertTrue(parser.InActiveCode())
+        self.assertTrue(parser.ProcessConditional('!endif'))
+
+        self.assertTrue(parser.ProcessConditional('!if $(MAX_SOCKET)==4'))
+        self.assertTrue(parser.InActiveCode())
         self.assertTrue(parser.ProcessConditional('!endif'))
 
 

--- a/tests.unit/parsers/test_base_parser.py
+++ b/tests.unit/parsers/test_base_parser.py
@@ -512,7 +512,7 @@ class TestBaseParserConditionals(unittest.TestCase):
 
     def test_conditional_without_spaces(self):
         parser = BaseParser("")
-        parser.LocalVars = {"MAX_SOCKET": '4', 'TARGET': 'DEBUG'}
+        parser.LocalVars = {"MAX_SOCKET": '4'}
 
         self.assertTrue(parser.ProcessConditional('!if $(MAX_SOCKET)<=4'))
         self.assertTrue(parser.InActiveCode())
@@ -531,6 +531,10 @@ class TestBaseParserConditionals(unittest.TestCase):
         self.assertTrue(parser.ProcessConditional('!endif'))
 
         self.assertTrue(parser.ProcessConditional('!if $(MAX_SOCKET)==4'))
+        self.assertTrue(parser.InActiveCode())
+        self.assertTrue(parser.ProcessConditional('!endif'))
+
+        self.assertTrue(parser.ProcessConditional('!if $(MAX_SOCKET)!=4'))
         self.assertTrue(parser.InActiveCode())
         self.assertTrue(parser.ProcessConditional('!endif'))
 

--- a/tests.unit/parsers/test_base_parser.py
+++ b/tests.unit/parsers/test_base_parser.py
@@ -534,7 +534,7 @@ class TestBaseParserConditionals(unittest.TestCase):
         self.assertTrue(parser.InActiveCode())
         self.assertTrue(parser.ProcessConditional('!endif'))
 
-        self.assertTrue(parser.ProcessConditional('!if $(MAX_SOCKET)!=4'))
+        self.assertTrue(parser.ProcessConditional('!if $(MAX_SOCKET)!=3'))
         self.assertTrue(parser.InActiveCode())
         self.assertTrue(parser.ProcessConditional('!endif'))
 


### PR DESCRIPTION
add ability to parse a condition expression without spaces between the argument and the condition, so long as the condition starts with a [!, >, <, =]. This is to bring parody with the edk2 build system, which supports parsing this.

Examples now supported:

!if $(var)==TRUE
!if $(var) ==TRUE
!if $(var)== TRUE