### PR TITLE
buildreport_parser: Support component INF absolute paths

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/buildreport_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/buildreport_parser.py
@@ -313,6 +313,8 @@ class BuildReport(object):
             (None): If not found
         """
         for (k, v) in self.Modules.items():
+            if os.path.isabs(v.InfPath):
+                v.InfPath = self.PathConverter.GetEdk2RelativePathFromAbsolutePath(v.InfPath)
             if (v.InfPath.lower() == InfPath.lower()):
                 logging.debug("Found Module by InfPath: %s" % InfPath)
                 return v


### PR DESCRIPTION
A path from an ext dep used for an INF will be absolute. This causes the build report parser to fail to match that path to a component since the check is performed against a relative path.

This change checks if a path is absolute before the comparison. If so, the path is converted to a package path adjusted path for the comparison.