### PR TITLE
Update OS version to 17134 to limit DDInstall sections

### DIFF
--- a/edk2toollib/windows/capsule/inf_generator.py
+++ b/edk2toollib/windows/capsule/inf_generator.py
@@ -52,9 +52,9 @@ PnpLockdown=1
 CatalogFile={Name}.cat
 
 [Manufacturer]
-%MfgName% = Firmware,NT{Arch}.10.0...16299
+%MfgName% = Firmware,NT{Arch}.10.0...17134
 
-[Firmware.NT{Arch}.10.0...16299]
+[Firmware.NT{Arch}.10.0...17134]
 %FirmwareDesc% = Firmware_Install,UEFI\RES_{{{EsrtGuid}}}
 
 [Firmware_Install.NT]

--- a/edk2toollib/windows/capsule/inf_generator.py
+++ b/edk2toollib/windows/capsule/inf_generator.py
@@ -17,6 +17,7 @@ import re
 import uuid
 from typing import Optional
 
+OS_BUILD_VERSION_DIRID13_SUPPORT = '10.0...17134'
 
 class InfSection(object):
     """Object representing an INF Section."""
@@ -52,9 +53,9 @@ PnpLockdown=1
 CatalogFile={Name}.cat
 
 [Manufacturer]
-%MfgName% = Firmware,NT{Arch}.10.0...17134
+%MfgName% = Firmware,NT{Arch}.{OsBuildVersion}
 
-[Firmware.NT{Arch}.10.0...17134]
+[Firmware.NT{Arch}.{OsBuildVersion}]
 %FirmwareDesc% = Firmware_Install,UEFI\RES_{{{EsrtGuid}}}
 
 [Firmware_Install.NT]
@@ -331,6 +332,7 @@ HKLM,SYSTEM\CurrentControlSet\Control\FirmwareResources\{{{EsrtGuid}}},Policy,%R
             EsrtGuid=self.EsrtGuid,
             Provider=self.Provider,
             MfgName=self.Manufacturer,
+            OsBuildVersion=OS_BUILD_VERSION_DIRID13_SUPPORT,
             Description=self.Description,
             Rollback=RollbackString,
             FirmwareCopyFilesSection=copy_files,

--- a/edk2toollib/windows/capsule/inf_generator2.py
+++ b/edk2toollib/windows/capsule/inf_generator2.py
@@ -23,6 +23,7 @@ SUPPORTED_ARCH = {'amd64': 'amd64',
                   'aarch64': 'ARM64'
                   }
 
+OS_BUILD_VERSION_DIRID13_SUPPORT = '10.0...17134'
 
 class InfHeader(object):
     """The INF header at the start of the INF file."""
@@ -121,7 +122,7 @@ class InfHeader(object):
             CatalogFile={self.Name}.cat
 
             [Manufacturer]
-            %MfgName% = Firmware,NT{self.Arch}.10.0...17134
+            %MfgName% = Firmware,NT{self.Arch}.{OS_BUILD_VERSION_DIRID13_SUPPORT}
 
             """)
 
@@ -288,7 +289,7 @@ class InfFirmwareSections(object):
 
         This includes any InfFirmware objects in it.
         """
-        firmwareStr = f"[Firmware.NT{self.Arch}.10.0...17134]\n"
+        firmwareStr = f"[Firmware.NT{self.Arch}.{OS_BUILD_VERSION_DIRID13_SUPPORT}]\n"
         for InfFirmware in self.Sections.values():
             firmwareStr += f"%{InfFirmware.Tag}Desc% = {InfFirmware.Tag}_Install,UEFI\\RES_{{{InfFirmware.EsrtGuid}}}\n"
         firmwareStr += "\n"

--- a/edk2toollib/windows/capsule/inf_generator2.py
+++ b/edk2toollib/windows/capsule/inf_generator2.py
@@ -121,7 +121,7 @@ class InfHeader(object):
             CatalogFile={self.Name}.cat
 
             [Manufacturer]
-            %MfgName% = Firmware,NT{self.Arch}.10.0...16299
+            %MfgName% = Firmware,NT{self.Arch}.10.0...17134
 
             """)
 
@@ -288,7 +288,7 @@ class InfFirmwareSections(object):
 
         This includes any InfFirmware objects in it.
         """
-        firmwareStr = f"[Firmware.NT{self.Arch}.10.0...16299]\n"
+        firmwareStr = f"[Firmware.NT{self.Arch}.10.0...17134]\n"
         for InfFirmware in self.Sections.values():
             firmwareStr += f"%{InfFirmware.Tag}Desc% = {InfFirmware.Tag}_Install,UEFI\\RES_{{{InfFirmware.EsrtGuid}}}\n"
         firmwareStr += "\n"

--- a/tests.unit/test_inf_generator.py
+++ b/tests.unit/test_inf_generator.py
@@ -11,7 +11,7 @@ import os
 import tempfile
 import unittest
 
-from edk2toollib.windows.capsule.inf_generator import InfGenerator, InfSection
+from edk2toollib.windows.capsule.inf_generator import InfGenerator, InfSection, OS_BUILD_VERSION_DIRID13_SUPPORT
 
 
 def _get_test_file():
@@ -137,7 +137,7 @@ class InfGeneratorTest(unittest.TestCase):
 
 # NOTE: Below are the expected contents of a a valid INF file.
 #       Some fields will need to be generated (like the date).
-TEST_FILE_CONTENTS = ''';
+TEST_FILE_CONTENTS = f''';
 ; TestName.inf
 ; 1.2.3.4
 ; Copyright (C) 2019 Microsoft Corporation.  All Rights Reserved.
@@ -145,17 +145,17 @@ TEST_FILE_CONTENTS = ''';
 [Version]
 Signature="$WINDOWS NT$"
 Class=Firmware
-ClassGuid={f2e7dd72-6468-4e36-b6f1-6488f42c1b52}
+ClassGuid={{f2e7dd72-6468-4e36-b6f1-6488f42c1b52}}
 Provider=%Provider%
 DriverVer=<DATESUB>,1.2.3.4
 PnpLockdown=1
 CatalogFile=TestName.cat
 
 [Manufacturer]
-%MfgName% = Firmware,NTamd64.10.0...17134
+%MfgName% = Firmware,NTamd64.{OS_BUILD_VERSION_DIRID13_SUPPORT}
 
-[Firmware.NTamd64.10.0...17134]
-%FirmwareDesc% = Firmware_Install,UEFI\\RES_{3cad7a0c-d35b-4b75-96b1-03a9fb07b7fc}
+[Firmware.NTamd64.{OS_BUILD_VERSION_DIRID13_SUPPORT}]
+%FirmwareDesc% = Firmware_Install,UEFI\\RES_{{3cad7a0c-d35b-4b75-96b1-03a9fb07b7fc}}
 
 [Firmware_Install.NT]
 CopyFiles = Firmware_CopyFiles
@@ -170,7 +170,7 @@ AddService=,2
 AddReg = Firmware_AddReg
 
 [Firmware_AddReg]
-HKR,,FirmwareId,,{3cad7a0c-d35b-4b75-96b1-03a9fb07b7fc}
+HKR,,FirmwareId,,{{3cad7a0c-d35b-4b75-96b1-03a9fb07b7fc}}
 HKR,,FirmwareVersion,%REG_DWORD%,0x1020304
 HKR,,FirmwareFilename,,%13%\\TestFirmwareRom.bin
 

--- a/tests.unit/test_inf_generator.py
+++ b/tests.unit/test_inf_generator.py
@@ -152,9 +152,9 @@ PnpLockdown=1
 CatalogFile=TestName.cat
 
 [Manufacturer]
-%MfgName% = Firmware,NTamd64.10.0...16299
+%MfgName% = Firmware,NTamd64.10.0...17134
 
-[Firmware.NTamd64.10.0...16299]
+[Firmware.NTamd64.10.0...17134]
 %FirmwareDesc% = Firmware_Install,UEFI\\RES_{3cad7a0c-d35b-4b75-96b1-03a9fb07b7fc}
 
 [Firmware_Install.NT]

--- a/tests.unit/test_inf_generator2.py
+++ b/tests.unit/test_inf_generator2.py
@@ -16,15 +16,15 @@ from edk2toollib.windows.capsule.inf_generator2 import (
     InfHeader,
     InfSourceFiles,
     InfStrings,
+    OS_BUILD_VERSION_DIRID13_SUPPORT
 )
-
 
 class InfHeaderTest(unittest.TestCase):
     def test_header(self):
         Strings = InfStrings()
         Header = InfHeader("InfTest", "1.0.0.1", "01/01/2021", "amd64", "testprovider", "testmfr", Strings)
 
-        ExpectedStr = textwrap.dedent("""\
+        ExpectedStr = textwrap.dedent(f"""\
             ;
             ; InfTest
             ; 1.0.0.1
@@ -33,14 +33,14 @@ class InfHeaderTest(unittest.TestCase):
             [Version]
             Signature="$WINDOWS NT$"
             Class=Firmware
-            ClassGuid={f2e7dd72-6468-4e36-b6f1-6488f42c1b52}
+            ClassGuid={{f2e7dd72-6468-4e36-b6f1-6488f42c1b52}}
             Provider=%Provider%
             DriverVer=01/01/2021,1.0.0.1
             PnpLockdown=1
             CatalogFile=InfTest.cat
 
             [Manufacturer]
-            %MfgName% = Firmware,NTamd64.10.0...17134
+            %MfgName% = Firmware,NTamd64.{OS_BUILD_VERSION_DIRID13_SUPPORT}
 
             """)
         self.assertEqual(ExpectedStr, str(Header))
@@ -273,9 +273,9 @@ class InfFirmwareSectionsTest(unittest.TestCase):
         Sections = InfFirmwareSections('amd64', Strings)
         Sections.AddSection(Firmware)
 
-        ExpectedStr = textwrap.dedent("""\
-            [Firmware.NTamd64.10.0...17134]
-            %tagDesc% = tag_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
+        ExpectedStr = textwrap.dedent(f"""\
+            [Firmware.NTamd64.{OS_BUILD_VERSION_DIRID13_SUPPORT}]
+            %tagDesc% = tag_Install,UEFI\\RES_{{34e094e9-4079-44cd-9450-3f2cb7824c97}}
 
             [tag_Install.NT]
             CopyFiles = tag_CopyFiles
@@ -290,7 +290,7 @@ class InfFirmwareSectionsTest(unittest.TestCase):
             AddReg = tag_AddReg
 
             [tag_AddReg]
-            HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
+            HKR,,FirmwareId,,{{34e094e9-4079-44cd-9450-3f2cb7824c97}}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
             HKR,,FirmwareFilename,,%13%\\test.bin
 
@@ -331,10 +331,10 @@ class InfFirmwareSectionsTest(unittest.TestCase):
         Sections.AddSection(Firmware1)
         Sections.AddSection(Firmware2)
 
-        ExpectedStr = textwrap.dedent("""\
-            [Firmware.NTamd64.10.0...17134]
-            %tag1Desc% = tag1_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
-            %tag2Desc% = tag2_Install,UEFI\\RES_{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
+        ExpectedStr = textwrap.dedent(f"""\
+            [Firmware.NTamd64.{OS_BUILD_VERSION_DIRID13_SUPPORT}]
+            %tag1Desc% = tag1_Install,UEFI\\RES_{{34e094e9-4079-44cd-9450-3f2cb7824c97}}
+            %tag2Desc% = tag2_Install,UEFI\\RES_{{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}}
 
             [tag1_Install.NT]
             CopyFiles = tag1_CopyFiles
@@ -349,7 +349,7 @@ class InfFirmwareSectionsTest(unittest.TestCase):
             AddReg = tag1_AddReg
 
             [tag1_AddReg]
-            HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
+            HKR,,FirmwareId,,{{34e094e9-4079-44cd-9450-3f2cb7824c97}}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
             HKR,,FirmwareFilename,,%13%\\test1.bin
 
@@ -366,7 +366,7 @@ class InfFirmwareSectionsTest(unittest.TestCase):
             AddReg = tag2_AddReg
 
             [tag2_AddReg]
-            HKR,,FirmwareId,,{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
+            HKR,,FirmwareId,,{{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000002
             HKR,,FirmwareFilename,,%13%\\test2.bin
 
@@ -490,7 +490,7 @@ class InfFileTest(unittest.TestCase):
             "0x01000002",
             "test2.bin")
 
-        ExpectedStr = textwrap.dedent("""\
+        ExpectedStr = textwrap.dedent(f"""\
             ;
             ; CapsuleName
             ; 1.0.0.1
@@ -499,18 +499,18 @@ class InfFileTest(unittest.TestCase):
             [Version]
             Signature="$WINDOWS NT$"
             Class=Firmware
-            ClassGuid={f2e7dd72-6468-4e36-b6f1-6488f42c1b52}
+            ClassGuid={{f2e7dd72-6468-4e36-b6f1-6488f42c1b52}}
             Provider=%Provider%
             DriverVer=01/01/2021,1.0.0.1
             PnpLockdown=1
             CatalogFile=CapsuleName.cat
 
             [Manufacturer]
-            %MfgName% = Firmware,NTamd64.10.0...17134
+            %MfgName% = Firmware,NTamd64.{OS_BUILD_VERSION_DIRID13_SUPPORT}
 
-            [Firmware.NTamd64.10.0...17134]
-            %tag1Desc% = tag1_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
-            %tag2Desc% = tag2_Install,UEFI\\RES_{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
+            [Firmware.NTamd64.{OS_BUILD_VERSION_DIRID13_SUPPORT}]
+            %tag1Desc% = tag1_Install,UEFI\\RES_{{34e094e9-4079-44cd-9450-3f2cb7824c97}}
+            %tag2Desc% = tag2_Install,UEFI\\RES_{{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}}
 
             [tag1_Install.NT]
             CopyFiles = tag1_CopyFiles
@@ -525,7 +525,7 @@ class InfFileTest(unittest.TestCase):
             AddReg = tag1_AddReg
 
             [tag1_AddReg]
-            HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
+            HKR,,FirmwareId,,{{34e094e9-4079-44cd-9450-3f2cb7824c97}}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
             HKR,,FirmwareFilename,,%13%\\test1.bin
 
@@ -542,7 +542,7 @@ class InfFileTest(unittest.TestCase):
             AddReg = tag2_AddReg
 
             [tag2_AddReg]
-            HKR,,FirmwareId,,{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
+            HKR,,FirmwareId,,{{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000002
             HKR,,FirmwareFilename,,%13%\\test2.bin
 
@@ -590,7 +590,7 @@ class InfFileTest(unittest.TestCase):
             "test2.bin",
             Rollback=True)
 
-        ExpectedStr = textwrap.dedent("""\
+        ExpectedStr = textwrap.dedent(f"""\
             ;
             ; CapsuleName
             ; 1.0.0.1
@@ -599,25 +599,25 @@ class InfFileTest(unittest.TestCase):
             [Version]
             Signature="$WINDOWS NT$"
             Class=Firmware
-            ClassGuid={f2e7dd72-6468-4e36-b6f1-6488f42c1b52}
+            ClassGuid={{f2e7dd72-6468-4e36-b6f1-6488f42c1b52}}
             Provider=%Provider%
             DriverVer=01/01/2021,1.0.0.1
             PnpLockdown=1
             CatalogFile=CapsuleName.cat
 
             [Manufacturer]
-            %MfgName% = Firmware,NTamd64.10.0...17134
+            %MfgName% = Firmware,NTamd64.{OS_BUILD_VERSION_DIRID13_SUPPORT}
 
-            [Firmware.NTamd64.10.0...17134]
-            %tag1Desc% = tag1_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
-            %tag2Desc% = tag2_Install,UEFI\\RES_{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
+            [Firmware.NTamd64.{OS_BUILD_VERSION_DIRID13_SUPPORT}]
+            %tag1Desc% = tag1_Install,UEFI\\RES_{{34e094e9-4079-44cd-9450-3f2cb7824c97}}
+            %tag2Desc% = tag2_Install,UEFI\\RES_{{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}}
 
             [tag1_Install.NT]
             CopyFiles = tag1_CopyFiles
             AddReg = tag1_DowngradePolicy_AddReg
 
             [tag1_DowngradePolicy_AddReg]
-            HKLM,SYSTEM\\CurrentControlSet\\Control\\FirmwareResources\\{34e094e9-4079-44cd-9450-3f2cb7824c97},Policy,%REG_DWORD%,1
+            HKLM,SYSTEM\\CurrentControlSet\\Control\\FirmwareResources\\{{34e094e9-4079-44cd-9450-3f2cb7824c97}},Policy,%REG_DWORD%,1
 
             [tag1_CopyFiles]
             test1.bin
@@ -629,7 +629,7 @@ class InfFileTest(unittest.TestCase):
             AddReg = tag1_AddReg
 
             [tag1_AddReg]
-            HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
+            HKR,,FirmwareId,,{{34e094e9-4079-44cd-9450-3f2cb7824c97}}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
             HKR,,FirmwareFilename,,%13%\\test1.bin
 
@@ -638,7 +638,7 @@ class InfFileTest(unittest.TestCase):
             AddReg = tag2_DowngradePolicy_AddReg
 
             [tag2_DowngradePolicy_AddReg]
-            HKLM,SYSTEM\\CurrentControlSet\\Control\\FirmwareResources\\{bec9124f-9934-4ec0-a6ed-b8bc1c91d276},Policy,%REG_DWORD%,1
+            HKLM,SYSTEM\\CurrentControlSet\\Control\\FirmwareResources\\{{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}},Policy,%REG_DWORD%,1
 
             [tag2_CopyFiles]
             test2.bin
@@ -650,7 +650,7 @@ class InfFileTest(unittest.TestCase):
             AddReg = tag2_AddReg
 
             [tag2_AddReg]
-            HKR,,FirmwareId,,{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
+            HKR,,FirmwareId,,{{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000002
             HKR,,FirmwareFilename,,%13%\\test2.bin
 
@@ -700,7 +700,7 @@ class InfFileTest(unittest.TestCase):
             Rollback=True,
             IntegrityFile="integrity2.bin")
 
-        ExpectedStr = textwrap.dedent("""\
+        ExpectedStr = textwrap.dedent(f"""\
             ;
             ; CapsuleName
             ; 1.0.0.1
@@ -709,25 +709,25 @@ class InfFileTest(unittest.TestCase):
             [Version]
             Signature="$WINDOWS NT$"
             Class=Firmware
-            ClassGuid={f2e7dd72-6468-4e36-b6f1-6488f42c1b52}
+            ClassGuid={{f2e7dd72-6468-4e36-b6f1-6488f42c1b52}}
             Provider=%Provider%
             DriverVer=01/01/2021,1.0.0.1
             PnpLockdown=1
             CatalogFile=CapsuleName.cat
 
             [Manufacturer]
-            %MfgName% = Firmware,NTamd64.10.0...17134
+            %MfgName% = Firmware,NTamd64.{OS_BUILD_VERSION_DIRID13_SUPPORT}
 
-            [Firmware.NTamd64.10.0...17134]
-            %tag1Desc% = tag1_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
-            %tag2Desc% = tag2_Install,UEFI\\RES_{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
+            [Firmware.NTamd64.{OS_BUILD_VERSION_DIRID13_SUPPORT}]
+            %tag1Desc% = tag1_Install,UEFI\\RES_{{34e094e9-4079-44cd-9450-3f2cb7824c97}}
+            %tag2Desc% = tag2_Install,UEFI\\RES_{{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}}
 
             [tag1_Install.NT]
             CopyFiles = tag1_CopyFiles
             AddReg = tag1_DowngradePolicy_AddReg
 
             [tag1_DowngradePolicy_AddReg]
-            HKLM,SYSTEM\\CurrentControlSet\\Control\\FirmwareResources\\{34e094e9-4079-44cd-9450-3f2cb7824c97},Policy,%REG_DWORD%,1
+            HKLM,SYSTEM\\CurrentControlSet\\Control\\FirmwareResources\\{{34e094e9-4079-44cd-9450-3f2cb7824c97}},Policy,%REG_DWORD%,1
 
             [tag1_CopyFiles]
             test1.bin
@@ -740,7 +740,7 @@ class InfFileTest(unittest.TestCase):
             AddReg = tag1_AddReg
 
             [tag1_AddReg]
-            HKR,,FirmwareId,,{34e094e9-4079-44cd-9450-3f2cb7824c97}
+            HKR,,FirmwareId,,{{34e094e9-4079-44cd-9450-3f2cb7824c97}}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000001
             HKR,,FirmwareFilename,,%13%\\test1.bin
             HKR,,FirmwareIntegrityFilename,,%13%\\integrity1.bin
@@ -750,7 +750,7 @@ class InfFileTest(unittest.TestCase):
             AddReg = tag2_DowngradePolicy_AddReg
 
             [tag2_DowngradePolicy_AddReg]
-            HKLM,SYSTEM\\CurrentControlSet\\Control\\FirmwareResources\\{bec9124f-9934-4ec0-a6ed-b8bc1c91d276},Policy,%REG_DWORD%,1
+            HKLM,SYSTEM\\CurrentControlSet\\Control\\FirmwareResources\\{{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}},Policy,%REG_DWORD%,1
 
             [tag2_CopyFiles]
             test2.bin
@@ -763,7 +763,7 @@ class InfFileTest(unittest.TestCase):
             AddReg = tag2_AddReg
 
             [tag2_AddReg]
-            HKR,,FirmwareId,,{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
+            HKR,,FirmwareId,,{{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}}
             HKR,,FirmwareVersion,%REG_DWORD%,0x1000002
             HKR,,FirmwareFilename,,%13%\\test2.bin
             HKR,,FirmwareIntegrityFilename,,%13%\\integrity2.bin

--- a/tests.unit/test_inf_generator2.py
+++ b/tests.unit/test_inf_generator2.py
@@ -40,7 +40,7 @@ class InfHeaderTest(unittest.TestCase):
             CatalogFile=InfTest.cat
 
             [Manufacturer]
-            %MfgName% = Firmware,NTamd64.10.0...16299
+            %MfgName% = Firmware,NTamd64.10.0...17134
 
             """)
         self.assertEqual(ExpectedStr, str(Header))
@@ -274,7 +274,7 @@ class InfFirmwareSectionsTest(unittest.TestCase):
         Sections.AddSection(Firmware)
 
         ExpectedStr = textwrap.dedent("""\
-            [Firmware.NTamd64.10.0...16299]
+            [Firmware.NTamd64.10.0...17134]
             %tagDesc% = tag_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
 
             [tag_Install.NT]
@@ -332,7 +332,7 @@ class InfFirmwareSectionsTest(unittest.TestCase):
         Sections.AddSection(Firmware2)
 
         ExpectedStr = textwrap.dedent("""\
-            [Firmware.NTamd64.10.0...16299]
+            [Firmware.NTamd64.10.0...17134]
             %tag1Desc% = tag1_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
             %tag2Desc% = tag2_Install,UEFI\\RES_{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
 
@@ -506,9 +506,9 @@ class InfFileTest(unittest.TestCase):
             CatalogFile=CapsuleName.cat
 
             [Manufacturer]
-            %MfgName% = Firmware,NTamd64.10.0...16299
+            %MfgName% = Firmware,NTamd64.10.0...17134
 
-            [Firmware.NTamd64.10.0...16299]
+            [Firmware.NTamd64.10.0...17134]
             %tag1Desc% = tag1_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
             %tag2Desc% = tag2_Install,UEFI\\RES_{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
 
@@ -606,9 +606,9 @@ class InfFileTest(unittest.TestCase):
             CatalogFile=CapsuleName.cat
 
             [Manufacturer]
-            %MfgName% = Firmware,NTamd64.10.0...16299
+            %MfgName% = Firmware,NTamd64.10.0...17134
 
-            [Firmware.NTamd64.10.0...16299]
+            [Firmware.NTamd64.10.0...17134]
             %tag1Desc% = tag1_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
             %tag2Desc% = tag2_Install,UEFI\\RES_{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
 
@@ -716,9 +716,9 @@ class InfFileTest(unittest.TestCase):
             CatalogFile=CapsuleName.cat
 
             [Manufacturer]
-            %MfgName% = Firmware,NTamd64.10.0...16299
+            %MfgName% = Firmware,NTamd64.10.0...17134
 
-            [Firmware.NTamd64.10.0...16299]
+            [Firmware.NTamd64.10.0...17134]
             %tag1Desc% = tag1_Install,UEFI\\RES_{34e094e9-4079-44cd-9450-3f2cb7824c97}
             %tag2Desc% = tag2_Install,UEFI\\RES_{bec9124f-9934-4ec0-a6ed-b8bc1c91d276}
 


### PR DESCRIPTION
Limit capsule install inf changes to OS versions 17134 or higher for a newer HDC requirement.
Original PR - https://github.com/tianocore/edk2-pytool-library/pull/431

"According to Zac Lockard for the InfVerif team, the new WHCP requirements went into force with the newest 26080 build which is why we're seeing this now. For reference, they link https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/inf-validation-errors-and-warnings#1199 and quote the page that says "You must fix all errors in order to pass driver tests in Hardware Dev Center."

It is the Device.DevFund.INF.Syntax requirement

This change was also pushed to all older versions of the OS due to this being a problem often in the ecosystem".