### PR TITLE
os/UefiVariableSupport: Support null termination

### DIFF
--- a/edk2toollib/os/uefivariablesupport.py
+++ b/edk2toollib/os/uefivariablesupport.py
@@ -122,6 +122,10 @@ class UefiVariable(object):
             Tuple: (error code, string of variable data)
         """
         err = 0
+
+        # Remove null termination on the name, if it exists.
+        name = name.rstrip('\x00')
+
         if os.name == 'nt':
             efi_var = create_string_buffer(EFI_VAR_MAX_BUFFER_SIZE)
             if self._GetFirmwareEnvironmentVariable is not None:
@@ -267,6 +271,9 @@ class UefiVariable(object):
         """
         success = 0  # Fail
 
+        # Remove null termination on the name, if it exists.
+        name = name.rstrip('\x00')
+
         if os.name == 'nt':
             var_len = 0
             err = 0
@@ -306,8 +313,7 @@ class UefiVariable(object):
                 logging.error(WinError())
             return success
         else:
-            # There is a null terminator at the end of the name
-            path = '/sys/firmware/efi/efivars/' + name[:-1] + '-' + str(guid)
+            path = '/sys/firmware/efi/efivars/' + name + '-' + str(guid)
             if var is None:
                 # we are deleting the variable
                 if (os.path.exists(path)):


### PR DESCRIPTION
Some consumers of the previous UefiSetVar and UefiGetVar were adding null termination, while others were not. 

Modifying script to strip null termination to handle both cases correctly. 