### PR TITLE
Address Linux GetUefiVariable exception. 

### DIFF
--- a/edk2toollib/os/uefivariablesupport.py
+++ b/edk2toollib/os/uefivariablesupport.py
@@ -122,6 +122,7 @@ class UefiVariable(object):
             Tuple: (error code, string of variable data)
         """
         err = 0
+        length = 0
 
         # Remove null termination on the name, if it exists.
         name = name.rstrip('\x00')
@@ -158,6 +159,7 @@ class UefiVariable(object):
             efi_var = create_string_buffer(EFI_VAR_MAX_BUFFER_SIZE)
             with open(path, 'rb') as fd:
                 efi_var = fd.read()
+                length = len(efi_var)
 
             return (err, efi_var[:length])
 


### PR DESCRIPTION
GetUefiVariable originally returned a buffer which was larger than the variable size. 
This was modified to only return the buffer of the variable size, but the modification caused an exception (variable not initialized).
Modifying the code again to initialize the variable, and to retrieve the correct variable size. 