### PR TITLE
Fix PCD parsing for PCDs that have a single quote in them

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/dec_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/dec_parser.py
@@ -127,7 +127,7 @@ class PcdDeclarationEntry():
         self.token_space_name = sp[0].strip()
 
         # Regular expression pattern to match the symbol '|' that is not inside quotes
-        pattern = r'\|(?=(?:[^\'"]*[\'"][^\'"]*[\'"])*[^\'"]*$)'
+        pattern = r'\|(?=(?:(?:[^\'"]*(?:\'[^\']*\'|"[^"]*"))*[^\'"]*)$)'
         op = re.split(pattern, sp[2])
 
         # if it's 2 long, we need to check that it's a structured PCD

--- a/tests.unit/parsers/test_dec_parser.py
+++ b/tests.unit/parsers/test_dec_parser.py
@@ -127,6 +127,15 @@ class TestPcdDeclarationEntry(unittest.TestCase):
         self.assertEqual(a.type, "VOID*")
         self.assertEqual(a.id, "0x00010001")
 
+    def test_string_containing_single_quote(self):
+        SAMPLE_DATA_DECL = """gTestTokenSpaceGuid.PcdSingleQuote|"eng'fraengfra"|VOID*|0x00010001"""
+        a = PcdDeclarationEntry("testpkg", SAMPLE_DATA_DECL)
+        self.assertEqual(a.token_space_name, "gTestTokenSpaceGuid")
+        self.assertEqual(a.name, "PcdTestString")
+        self.assertEqual(a.default_value, "\"eng'fraengfra\"")
+        self.assertEqual(a.type, "VOID*")
+        self.assertEqual(a.id, "0x00010001")
+
 class TestDecParser(unittest.TestCase):
 
     SAMPLE_DEC_FILE = \

--- a/tests.unit/parsers/test_dec_parser.py
+++ b/tests.unit/parsers/test_dec_parser.py
@@ -128,7 +128,7 @@ class TestPcdDeclarationEntry(unittest.TestCase):
         self.assertEqual(a.id, "0x00010001")
 
     def test_string_containing_single_quote(self):
-        SAMPLE_DATA_DECL = """gTestTokenSpaceGuid.PcdSingleQuote|"eng'fraengfra"|VOID*|0x00010001"""
+        SAMPLE_DATA_DECL = """gTestTokenSpaceGuid.PcdTestString|"eng'fraengfra"|VOID*|0x00010001"""
         a = PcdDeclarationEntry("testpkg", SAMPLE_DATA_DECL)
         self.assertEqual(a.token_space_name, "gTestTokenSpaceGuid")
         self.assertEqual(a.name, "PcdTestString")


### PR DESCRIPTION
The PCD parsing regex pattern failed for PCDs that had a single quote

For example, 
gEfiMdePkgTokenSpaceGuid.PcdSingleQuote|"eng'fraengfra"|VOID*|0x0000002f
CRITICAL - EXCEPTION: Too few parts: ['PcdSingleQuote|"eng\'fraengfra"', 'VOID*', '0x0000002f']

The new pattern should allow the usage of single quotes