### PR TITLE
Documentation: Fix all broken links

### DIFF
--- a/docs/user/features/edk2_db.md
+++ b/docs/user/features/edk2_db.md
@@ -84,7 +84,7 @@ db.parse(env)
 
 ## Table Generators
 
-Table generators are just that, classes that subclass the [TableGenerator](/api/database/edk2_db/#edk2toollib.database.edk2_db.TableGenerator)
+Table generators are just that, classes that subclass the [TableGenerator](/api/database/edk2_db.md#edk2toollib.database.edk2_db.TableGenerator)
 , parse some type of information (typically the workspace) and insert the data into one of the tables managed by Edk2DB.
 Multiple table generators are provided by edk2toollib, and can be seen at [edk2toollib.database.tables](https://github.com/tianocore/edk2-pytool-library/tree/master/edk2toollib/database/tables).
 Edk2DB can use any class that implements the `TableGenerator` interface.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,12 @@ repo_url: https://github.com/tianocore/edk2-pytool-library
 copyright: Copyright (c) Microsoft.  All rights reserved
 site_description: edk2toollib package documentation
 
+validation:
+  links:
+    absolute_links: relative_to_docs
+    anchors: warn
+    unrecognized_links: warn
+
 theme:
   name: material
   features:


### PR DESCRIPTION
[MkDocs v1.5.0](https://github.com/mkdocs/mkdocs/releases/1.5.0) Updated how links were evaluated (See "Expanded Validaton of links" section). Before 1.5.0, most links in our documentation were left "untouched" as they either started or ended with a `/`.

> ... links that started with `/` ("absolute") and links that _ended_ with `/` were left as is ...

However these links are now properly evaluated, which broke most links in edk2-pytool-extensions documentation. With this new evaluation, All of our links that started absolute (`/`) were now linking relative to `tianocore.org` instead of `tianocore.org/edk2-pytool-library`.

This pull request updates the documentation to utilize the newly introduced `absolute_links` validation setting to be `relative_to_docs` which updates absolute paths to be relative to `tianocore.org/edk2-pytool-extensions` and updates any path references to point to the markdown file, which is necessary for the `relative_to_docs` setting to work as expected.