### PR TITLE
gitignore_parser.py: Handle non-subpaths in rule file check

### DIFF
--- a/edk2toollib/gitignore_parser.py
+++ b/edk2toollib/gitignore_parser.py
@@ -181,7 +181,13 @@ class IgnoreRule(collections.namedtuple("IgnoreRule_", IGNORE_RULE_FIELDS)):
         """Returns True or False if the path matches the rule."""
         matched = False
         if self.base_path:
-            rel_path = _normalize_path(abs_path).relative_to(self.base_path).as_posix()
+            try:
+                rel_path = _normalize_path(abs_path).relative_to(self.base_path).as_posix()
+            except ValueError as e:
+                if "is not in the subpath of" in str(e):
+                    return False
+                else:
+                    raise
         else:
             rel_path = _normalize_path(abs_path).as_posix()
         # Path() strips the trailing following symbols on windows, so we need to

--- a/tests.unit/parsers/test_gitingore_parser.py
+++ b/tests.unit/parsers/test_gitingore_parser.py
@@ -249,6 +249,21 @@ def test_incomplete_filename(tmp_path):
     assert rule_tester("/home/tmp/dir/o.pyc") is False
 
 
+
+def test_unrelated_path(tmp_path):
+    """Tests that a path that is completely unrelated to another path works."""
+    root = tmp_path.resolve()
+    gitignore_path = root / ".gitignore"
+
+    with open(gitignore_path, 'w') as f:
+        f.write('*foo*\n')
+
+    rule_tester = gitignore_parser.parse_gitignore_file(gitignore_path, base_dir='/home/tmp')
+
+    assert rule_tester('/home/tmp/foo') is True
+    assert rule_tester('/some/other/dir') is False
+
+
 def test_double_asterisks(tmp_path):
     """Test that double asterisk match any number of directories."""
     root = tmp_path.resolve()


### PR DESCRIPTION
In IgnoreRule.match(), simply return False if the given absolute path is not a subpath of the base path instead of not handling the exception and breaking the overall build.