### PR TITLE
[REBASE&FF] Run ruff check and ruff format on the workspace

### DIFF
--- a/.github/workflows/CIRunner.yml
+++ b/.github/workflows/CIRunner.yml
@@ -52,9 +52,13 @@ jobs:
         npm install -g markdownlint-cli@0.39.0
         npm install -g cspell@5.20.0
 
-    - name: Run ruff
+    - name: Run ruff linter
       if: success() || failure()
-      run: ruff check ${{ inputs.package-src }} --output-format=github
+      run: ruff check --output-format=github .
+
+    - name: Run ruff formatter
+      if: success() || failure()
+      run: ruff format --check .
 
     - name: Run markdownlint
       if: success() || failure()

--- a/docs/contributor/developing.md
+++ b/docs/contributor/developing.md
@@ -84,6 +84,7 @@ as described above.
 
       ``` cmd
       ruff check .
+      ruff format --check .
       ```
 
       * Note: Newer editors are very helpful in resolving source formatting errors. For example, in VSCode, you can

--- a/tests.unit/parsers/test_gitingore_parser.py
+++ b/tests.unit/parsers/test_gitingore_parser.py
@@ -249,19 +249,18 @@ def test_incomplete_filename(tmp_path):
     assert rule_tester("/home/tmp/dir/o.pyc") is False
 
 
-
 def test_unrelated_path(tmp_path):
     """Tests that a path that is completely unrelated to another path works."""
     root = tmp_path.resolve()
     gitignore_path = root / ".gitignore"
 
-    with open(gitignore_path, 'w') as f:
-        f.write('*foo*\n')
+    with open(gitignore_path, "w") as f:
+        f.write("*foo*\n")
 
-    rule_tester = gitignore_parser.parse_gitignore_file(gitignore_path, base_dir='/home/tmp')
+    rule_tester = gitignore_parser.parse_gitignore_file(gitignore_path, base_dir="/home/tmp")
 
-    assert rule_tester('/home/tmp/foo') is True
-    assert rule_tester('/some/other/dir') is False
+    assert rule_tester("/home/tmp/foo") is True
+    assert rule_tester("/some/other/dir") is False
 
 
 def test_double_asterisks(tmp_path):


### PR DESCRIPTION
Update the pipelines and documentation to specify that `ruff check` and `ruff format` should be (and will be in the pipelines) run on the workspace