### PR TITLE
Python support: drop 3.10, add 3.13

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,16 +48,16 @@ body:
       description: "Note: Bug fixes are only supported on these Python versions."
       multiple: true
       options:
-        - Python 3.10
         - Python 3.11
         - Python 3.12
+        - Python 3.13
     validations:
       required: true
   - type: textarea
     id: env
     attributes:
       label: Execution Environment
-      description: "List the OS, python micro version (e.g. 3.10.8), system environment variables, etc."
+      description: "List the OS, python micro version (e.g. 3.11), system environment variables, etc."
     validations:
       required: false
   - type: textarea

--- a/.github/workflows/VariableProducer.yml
+++ b/.github/workflows/VariableProducer.yml
@@ -14,7 +14,7 @@ on:
         value: ${{ jobs.produce.outputs.node-versions }}
 
 env:
-  pythonversions: "['3.12', '3.11', '3.10']" # Keep Python Versions in descending order
+  pythonversions: "['3.13', '3.12', '3.11']" # Keep Python Versions in descending order
   nodeversions: "['19']"
 
 jobs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dynamic = ["version"]
 description = "Python library supporting UEFI EDK2 firmware development"
 readme = {file = "readme.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "pyasn1 >= 0.4.8",
     "pyasn1-modules >= 0.2.8",
@@ -18,7 +18,7 @@ dependencies = [
     "GitPython >= 3.1.30",
     "sqlalchemy >= 2.0.0",
     "pygount >= 1.6.1",
-    "pywin32==306 ; sys_platform == 'win32'",
+    "pywin32==308 ; sys_platform == 'win32'",
 ]
 classifiers=[
         "Programming Language :: Python :: 3",
@@ -26,9 +26,9 @@ classifiers=[
         "Operating System :: OS Independent",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
-        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12"
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13"
     ]
 
 [project.urls]

--- a/readme.md
+++ b/readme.md
@@ -26,15 +26,15 @@ Supported Versions
 
 |  Host Type         |  Toolchain    |  Status
 |  :---------------  |  :----------  |  :--------------------
-|  [Windows-Latest]  |  Python 3.10  |  [![ci]][_ci]
 |  [Windows-Latest]  |  Python 3.11  |  [![ci]][_ci]
 |  [Windows-Latest]  |  Python 3.12  |  [![ci]][_ci]
-|  [Ubuntu-Latest]   |  Python 3.10  |  [![ci]][_ci]
+|  [Windows-Latest]  |  Python 3.13  |  [![ci]][_ci]
 |  [Ubuntu-Latest]   |  Python 3.11  |  [![ci]][_ci]
 |  [Ubuntu-Latest]   |  Python 3.12  |  [![ci]][_ci]
-|  [MacOS-Latest]    |  Python 3.10  |  [![coming_soon]][_ci]
+|  [Ubuntu-Latest]   |  Python 3.13  |  [![ci]][_ci]
 |  [MacOS-Latest]    |  Python 3.11  |  [![coming_soon]][_ci]
 |  [MacOS-Latest]    |  Python 3.12  |  [![coming_soon]][_ci]
+|  [MacOS-Latest]    |  Python 3.13  |  [![coming_soon]][_ci]
 
 ### Current Release
 


### PR DESCRIPTION
## Breaking Change

This commit removes support for python 3.10. Attempting to install v0.22.0 of edk2-pytool-library using a python version less than 3.11 will result in an error from pip along the lines of `ERROR: Could not find a version that satisfies the requirement ...`

## Integration Instructions

If your platform cannot upgrade to 3.11 or above, continue using a version of edk2-python-library less than v0.22.0. Otherwise upgrade your version of platform to 3.11 or greater.