### PR TITLE
base_parser.py: support conditions checking for empty string

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/base_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/base_parser.py
@@ -546,12 +546,14 @@ class BaseParser(object):
         mode = 0
         tokens = []
         for character in text:
-            if character == '"' and len(token) == 0:
+            if character == '"' and len(token) == 0 and mode != QUOTE_MODE:
                 mode = QUOTE_MODE
             elif character == '"' and mode == QUOTE_MODE:
                 if len(token) > 0:
                     tokens.append(f'"{token}"')
                     token = ""
+                else:
+                    tokens.append('""')
                 mode = TEXT_MODE
             elif character == "$" and len(token) == 0:
                 token += character


### PR DESCRIPTION
base_parser.py did not support conditional directives that were comparing to empty strings (e.g. `!if $(MY_VAL) == ""`, `!if $(MY_VAL) != "". The logic in `_TokenizeConditional`, was setting `mode` to QUOTE_MODE twice because the token length was zero for an empty quote (`len(token) == 0`).

This PR Updates the logic to not enter QUOTE_MODE when its already in QUOTE_MODE, and to fall over to end of QUOTE_MODE.