### PR TITLE
fdf_parser.py: support `SECTION COMPRESS` sections

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/fdf_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/fdf_parser.py
@@ -180,7 +180,9 @@ class FdfParser(HashFileParser):
                                     self.FVs[section]["Files"][currentName][sectionType] = {}
                                 # TODO support guided sections
                             # ex: SECTION UI = "GenericGopDriver"
-                            elif sline.upper().startswith("SECTION"):  # get the section
+                            elif (
+                                sline.upper().startswith("SECTION") and sline.upper().count("=") > 0
+                            ):  # get the section
                                 section_def = sline[7:].strip().split("=", 1)
                                 sectionType = section_def[0].strip()  # UI in this example
                                 sectionValue = section_def[1].strip()


### PR DESCRIPTION
Previously, the FDF parser would fail to parse an FDF file with statements containing a SECTION COMPRESS with additional with nested sub sections. 

Below is an example of a statement the parser failed to parser:

```
FILE RAW = <guid> {
    SECTION COMPRESS {
      SECTION RAW = $(OUTPUT_DIRECTORY)/$(TARGET)_$(TOOL_CHAIN_TAG)/FV/8C3D856A-9BE6-468E-850A-24F7A8D38E08.bin
    }
}
```

This PR updates the parser to be able to get past the parsing of the this, by checking there is an equal in the statement line, and pass it.

