### PR TITLE
Update GetEdk2RelativePathFromAbsolutePath and GetAbsolutePathOnThisSystemFromEdk2RelativePath path input type hinting

### DIFF
--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -16,7 +16,7 @@ import errno
 import logging
 import os
 from pathlib import Path
-from typing import Iterable, Optional, Tuple
+from typing import Iterable, Optional
 
 
 class Edk2Path(object):
@@ -144,7 +144,7 @@ class Edk2Path(object):
         """List of package paths as strings."""
         return [str(p) for p in self._package_path_list]
 
-    def GetEdk2RelativePathFromAbsolutePath(self, *abspath: Tuple[str, ...]) -> str:
+    def GetEdk2RelativePathFromAbsolutePath(self, *abspath: str) -> str:
         """Transforms an absolute path to an edk2 path relative to the workspace or a packages path.
 
         Args:
@@ -200,9 +200,7 @@ class Edk2Path(object):
         self.logger.error(f"AbsolutePath: {abspath}")
         return None
 
-    def GetAbsolutePathOnThisSystemFromEdk2RelativePath(
-        self, *relpath: Tuple[str, ...], log_errors: Optional[bool] = True
-    ) -> str:
+    def GetAbsolutePathOnThisSystemFromEdk2RelativePath(self, *relpath: str, log_errors: Optional[bool] = True) -> str:
         """Given a relative path return an absolute path to the file in this workspace.
 
         Args:


### PR DESCRIPTION
For GetEdk2RelativePathFromAbsolutePath change the type hinting of abspath from Tuple of strings to just str.
For GetAbsolutePathOnThisSystemFromEdk2RelativePath change the type hinting of relpath from Tuple of strings to just str.

This fixes the error messages from Pylint and Ruff about incompatible input types when using the functions as suggested. When attempting to pass a Tuple of strings to the functions, the functions would raise an error.

```
File "...\site-packages\edk2toollib\uefi\edk2\path_utilities.py", line 224, in GetAbsolutePathOnThisSystemFromEdk2RelativePath
    relpath = Path(*[part.replace("\\", "/") for part in relpath])
                     ^^^^^^^^^^^^
AttributeError: 'tuple' object has no attribute 'replace'
```