### PR TITLE
Set default stream encoding to utf-8 to `logging` handlers

### DIFF
--- a/edk2toollib/log/file_handler.py
+++ b/edk2toollib/log/file_handler.py
@@ -13,9 +13,9 @@ import logging
 class FileHandler(logging.FileHandler):
     """Object for handling basic logging output to files."""
 
-    def __init__(self, filename: str, mode: str = "w+") -> "FileHandler":
+    def __init__(self, filename: str, mode: str = "w+", encoding="utf-8") -> "FileHandler":
         """Init a file handler for the specified file."""
-        logging.FileHandler.__init__(self, filename, mode=mode)
+        logging.FileHandler.__init__(self, filename, mode=mode, encoding=encoding)
 
     def handle(self, record: logging.LogRecord) -> bool:
         """Conditionally emit the specified logging record.

--- a/edk2toollib/log/junit_report_format.py
+++ b/edk2toollib/log/junit_report_format.py
@@ -197,7 +197,7 @@ class JunitTestReport(object):
 
     def Output(self, filepath: str) -> None:
         """Write report to file."""
-        f = open(filepath, "w")
+        f = open(filepath, "w", encoding="utf-8")
         f.write("")
         f.write('<?xml version="1.0" encoding="UTF-8"?>')
         f.write("<testsuites>")


### PR DESCRIPTION
With the addition of characters that require unicode support to source files, it is necessary to a default encoding of `utf-8` to prevent errors such as `UnicodeEncodeError: 'charmap' codec can't encode character '\u017f' when parsing file names.`

Encountered when attempting to work with SecurityPkg in edk2-stable202411 and the addition of complex copyright names.