### PR TITLE
locate_tools: QueryVcVariables: Allow exact vc

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -105,6 +105,7 @@
         "toollib",
         "unittest",
         "urlunsplit",
+        "vcvars",
         "vcvarsall",
         "vsvars",
         "vswhere",

--- a/edk2toollib/windows/locate_tools.py
+++ b/edk2toollib/windows/locate_tools.py
@@ -198,7 +198,7 @@ def QueryVcVariables(
         arch (:obj:`str`, optional): arch to run
         product (:obj:`str`, optional): values defined by vswhere.exe
         vs_version (:obj:`str`, optional): helper to find version of supported VS version (example vs2019)
-        vc_version (:obj:`str`, optional): The exact compiler version to consider for searching for keys
+        vc_version (:obj:`str`, optional): Exact compiler version to consider for variables (example 14.42.34433)
 
     Returns:
         (dict): the appropriate environment variables

--- a/edk2toollib/windows/locate_tools.py
+++ b/edk2toollib/windows/locate_tools.py
@@ -186,7 +186,9 @@ def FindAllWithVsWhere(products: str = "*", vs_version: Optional[str] = None) ->
     return None
 
 
-def QueryVcVariables(keys: list, arch: str = None, product: str = None, vs_version: str = None, vc_version=None) -> str:
+def QueryVcVariables(
+    keys: list, arch: str = None, product: str = None, vs_version: str = None, vc_version: str = None
+) -> str:
     """Launch vcvarsall.bat and read the settings from its environment.
 
     This is a windows only function and Windows is case insensitive for the keys

--- a/edk2toollib/windows/locate_tools.py
+++ b/edk2toollib/windows/locate_tools.py
@@ -186,7 +186,7 @@ def FindAllWithVsWhere(products: str = "*", vs_version: Optional[str] = None) ->
     return None
 
 
-def QueryVcVariables(keys: list, arch: str = None, product: str = None, vs_version: str = None) -> str:
+def QueryVcVariables(keys: list, arch: str = None, product: str = None, vs_version: str = None, vc_version=None) -> str:
     """Launch vcvarsall.bat and read the settings from its environment.
 
     This is a windows only function and Windows is case insensitive for the keys
@@ -196,6 +196,7 @@ def QueryVcVariables(keys: list, arch: str = None, product: str = None, vs_versi
         arch (:obj:`str`, optional): arch to run
         product (:obj:`str`, optional): values defined by vswhere.exe
         vs_version (:obj:`str`, optional): helper to find version of supported VS version (example vs2019)
+        vc_version (:obj:`str`, optional): The exact compiler version to consider for searching for keys
 
     Returns:
         (dict): the appropriate environment variables
@@ -246,8 +247,15 @@ def QueryVcVariables(keys: list, arch: str = None, product: str = None, vs_versi
         logging.error(e)
         raise ValueError(e)
 
-    logging.debug("Calling '%s %s'", vcvarsall_path, arch)
-    popen = subprocess.Popen('"%s" %s & set' % (vcvarsall_path, arch), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if vc_version:
+        vc_version = f"-vcvars_ver={vc_version}"
+    else:
+        vc_version = ""
+
+    logging.debug("Calling '%s %s %s'", vcvarsall_path, arch, vc_version)
+    popen = subprocess.Popen(
+        '"%s" %s %s & set' % (vcvarsall_path, arch, vc_version), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
     try:
         stdout, stderr = popen.communicate()
         if popen.wait() != 0:

--- a/tests.unit/test_locate_tools.py
+++ b/tests.unit/test_locate_tools.py
@@ -151,6 +151,7 @@ def test_QueryVcVariablesWithLargEnv(caplog):
 
     os.environ = old_env
 
+
 @pytest.mark.skipif(not sys.platform.startswith("win"), reason="requires Windows")
 def test_QueryVcVariablesWithSpecificVc():
     """Tests QueryVcVariables with a specific VC version.
@@ -160,7 +161,7 @@ def test_QueryVcVariablesWithSpecificVc():
     lookup = locate_tools.QueryVcVariables(["VCToolsInstallDir"])
     assert "VCToolsInstallDir" in lookup
 
-    vc = pathlib.Path(lookup["VCToolsInstallDir"]).name # Folder is version
+    vc = pathlib.Path(lookup["VCToolsInstallDir"]).name  # Folder is version
 
     keys = ["VCINSTALLDIR", "WindowsSDKVersion", "LIB"]
     lookup = locate_tools.QueryVcVariables(keys, vc_version=vc)

--- a/tests.unit/test_locate_tools.py
+++ b/tests.unit/test_locate_tools.py
@@ -8,6 +8,7 @@
 ##
 
 import unittest
+import pathlib
 import pytest
 import logging
 import sys
@@ -149,3 +150,22 @@ def test_QueryVcVariablesWithLargEnv(caplog):
         locate_tools.QueryVcVariables(keys)
 
     os.environ = old_env
+
+@pytest.mark.skipif(not sys.platform.startswith("win"), reason="requires Windows")
+def test_QueryVcVariablesWithSpecificVc():
+    """Tests QueryVcVariables with a specific VC version.
+
+    This test will check that the function can query a specific VC version.
+    """
+    lookup = locate_tools.QueryVcVariables(["VCToolsInstallDir"])
+    assert "VCToolsInstallDir" in lookup
+
+    vc = pathlib.Path(lookup["VCToolsInstallDir"]).name # Folder is version
+
+    keys = ["VCINSTALLDIR", "WindowsSDKVersion", "LIB"]
+    lookup = locate_tools.QueryVcVariables(keys, vc_version=vc)
+    assert "VCINSTALLDIR" in lookup
+    assert "WindowsSDKVersion" in lookup
+    assert "LIB" in lookup
+
+    assert vc in lookup["LIB"]

--- a/tests.unit/test_locate_tools.py
+++ b/tests.unit/test_locate_tools.py
@@ -8,7 +8,6 @@
 ##
 
 import unittest
-import pathlib
 import pytest
 import logging
 import sys
@@ -158,15 +157,15 @@ def test_QueryVcVariablesWithSpecificVc():
 
     This test will check that the function can query a specific VC version.
     """
-    lookup = locate_tools.QueryVcVariables(["VCToolsInstallDir"])
-    assert "VCToolsInstallDir" in lookup
-
-    vc = pathlib.Path(lookup["VCToolsInstallDir"]).name  # Folder is version
-
-    keys = ["VCINSTALLDIR", "WindowsSDKVersion", "LIB"]
-    lookup = locate_tools.QueryVcVariables(keys, vc_version=vc)
+    lookup = locate_tools.QueryVcVariables(["VCINSTALLDIR", "WindowsSDKVersion"])
     assert "VCINSTALLDIR" in lookup
     assert "WindowsSDKVersion" in lookup
-    assert "LIB" in lookup
 
-    assert vc in lookup["LIB"]
+    # Fail to complete the lookup because the vc_version does not exist
+    try:
+        lookup = locate_tools.QueryVcVariables(["VCINSTALLDIR", "WindowsSDKVersion"], vc_version="9.9.9")
+    except ValueError as e:
+        assert str(e).startswith("Missing keys when querying vcvarsall")
+        lookup = None
+
+    assert lookup is None


### PR DESCRIPTION
Allows a caller to specify the exact compiler version to use for querying variables. This is useful because a system may have a single installation of (example) VS2022, but may have multiple versions of the VS2022 compiler installed. Prior to this change, QueryVcVariables would return variables arbitrarily based off of one of the installed compilers.

This change allows the caller to specify the exact version of the compiler to use for querying variables, so that the returned variables are consistent.

This allows for a bug regarding [WindowsVsToolChain](https://github.com/microsoft/mu_basecore/blob/dev/202405/BaseTools/Plugin/WindowsVsToolChain/WindowsVsToolChain.py) to be fixed as specified in: https://github.com/microsoft/mu_basecore/issues/1308