### PR TITLE
Optimize `Edk2Path` [Rebase & FF]

### DIFF
--- a/tests.unit/test_path_utilities.py
+++ b/tests.unit/test_path_utilities.py
@@ -1021,7 +1021,7 @@ class PathUtilitiesTest(unittest.TestCase):
         with self.assertLogs(logger="Edk2Path", level=logging.DEBUG) as logs:
             Edk2Path(folder_ws_abs, [folder_pp1_abs])
             Edk2Path(folder_ws_abs, [folder_pp1_abs, folder_pp2_abs])
-            self.assertEqual(len(logs.records), 2)
+            self.assertTrue(any("Nested packages are not allowed" in message for message in logs.output))
 
     def test_get_relative_path_when_folder_is_next_to_package(self):
         """Test usage of GetEdk2RelativePathFromAbsolutePath when a folder containing a package is in the same


### PR DESCRIPTION
**test_path_utilities: Remove debug message count assumption**

Test that a nested package is found by the strings in the debug
message as opposed to the number of messages to avoid the test
being broken when unrelated debug messages are added.

---

**path_utilities: Optimize `Edk2Path` constructor**

`Edk2Path` objects are created relatively frequently throughout a
complete build process. This reduces the average execution time
in a full workspace by approximately half by using `os.walk()`
which is several seconds faster in the workspace and parallelizing
across package paths.