### PR TITLE
Relax pywin dependency to be greater or equal instead of exactly equal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "GitPython >= 3.1.30",
     "sqlalchemy >= 2.0.0",
     "pygount >= 1.6.1",
-    "pywin32==308 ; sys_platform == 'win32'",
+    "pywin32 >= 308 ; sys_platform == 'win32'",
 ]
 classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Relax pywin dependency to be greater or equal to minimum version. 