### PR TITLE
Remove the sorted action for candidate_package_path_list

### DIFF
--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -97,7 +97,7 @@ class Edk2Path(object):
         end_time = timeit.default_timer()
         self.logger.log(logging.DEBUG, f"Time to check package paths: {end_time - start_time}")
 
-        self._package_path_list = sorted(candidate_package_path_list)
+        self._package_path_list = candidate_package_path_list
 
         if invalid_pp and error_on_invalid_pp:
             raise NotADirectoryError(errno.ENOENT, os.strerror(errno.ENOENT), invalid_pp)

--- a/tests.unit/test_path_utilities.py
+++ b/tests.unit/test_path_utilities.py
@@ -197,7 +197,6 @@ class PathUtilitiesTest(unittest.TestCase):
         self.assertEqual(pathobj.PackagePathList, [str(pp3), str(pp1), str(pp2)])
 
     @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
-
     def test_basic_init_ws_abs_different_case(self):
         inputPath = self.tmp.capitalize()
         if self.tmp[0].isupper():

--- a/tests.unit/test_path_utilities.py
+++ b/tests.unit/test_path_utilities.py
@@ -182,7 +182,6 @@ class PathUtilitiesTest(unittest.TestCase):
         # Make sure we don't throw an exception unless we mean to
         Edk2Path(str(ws), ["bad_pp_path", "bad_pp_path2", "good_path"], error_on_invalid_pp=False)
 
-    @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
     def test_package_path_list_order(self):
         """Test that the package path list is not changed by the constructor."""
         ws = Path(self.tmp, "folder_ws")
@@ -196,6 +195,8 @@ class PathUtilitiesTest(unittest.TestCase):
 
         pathobj = Edk2Path(str(ws), [str(pp3), str(pp1), str(pp2)])
         self.assertEqual(pathobj.PackagePathList, [str(pp3), str(pp1), str(pp2)])
+
+    @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
 
     def test_basic_init_ws_abs_different_case(self):
         inputPath = self.tmp.capitalize()

--- a/tests.unit/test_path_utilities.py
+++ b/tests.unit/test_path_utilities.py
@@ -183,6 +183,20 @@ class PathUtilitiesTest(unittest.TestCase):
         Edk2Path(str(ws), ["bad_pp_path", "bad_pp_path2", "good_path"], error_on_invalid_pp=False)
 
     @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
+    def test_package_path_list_order(self):
+        """Test that the package path list is ordered correctly."""
+        ws = Path(self.tmp, "folder_ws")
+        ws.mkdir()
+        pp1 = ws / "pp1"
+        pp1.mkdir()
+        pp2 = ws / "pp2"
+        pp2.mkdir()
+        pp3 = ws / "pp3"
+        pp3.mkdir()
+
+        pathobj = Edk2Path(str(ws), [str(pp3), str(pp1), str(pp2)])
+        self.assertEqual(pathobj.PackagePathList, [str(pp3), str(pp1), str(pp2)])
+
     def test_basic_init_ws_abs_different_case(self):
         inputPath = self.tmp.capitalize()
         if self.tmp[0].isupper():

--- a/tests.unit/test_path_utilities.py
+++ b/tests.unit/test_path_utilities.py
@@ -186,15 +186,15 @@ class PathUtilitiesTest(unittest.TestCase):
         """Test that the package path list is not changed by the constructor."""
         ws = Path(self.tmp, "folder_ws")
         ws.mkdir()
-        pp1 = ws / "pp1"
-        pp1.mkdir()
-        pp2 = ws / "pp2"
-        pp2.mkdir()
-        pp3 = ws / "pp3"
-        pp3.mkdir()
+        c_path = ws / "c_path"
+        c_path.mkdir()
+        b_path = ws / "b_path"
+        b_path.mkdir()
+        a_path = ws / "a_path"
+        a_path.mkdir()
 
-        pathobj = Edk2Path(str(ws), [str(pp3), str(pp1), str(pp2)])
-        self.assertEqual(pathobj.PackagePathList, [str(pp3), str(pp1), str(pp2)])
+        pathobj = Edk2Path(str(ws), [str(c_path), str(b_path), str(a_path)])
+        self.assertEqual(pathobj.PackagePathList, [str(c_path), str(b_path), str(a_path)])
 
     @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
     def test_basic_init_ws_abs_different_case(self):

--- a/tests.unit/test_path_utilities.py
+++ b/tests.unit/test_path_utilities.py
@@ -184,7 +184,7 @@ class PathUtilitiesTest(unittest.TestCase):
 
     @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
     def test_package_path_list_order(self):
-        """Test that the package path list is ordered correctly."""
+        """Test that the package path list is not changed by the constructor."""
         ws = Path(self.tmp, "folder_ws")
         ws.mkdir()
         pp1 = ws / "pp1"


### PR DESCRIPTION
Remove the sorted action for candidate_package_path_list to align with original build behavior.