### PR TITLE
pyproject.tom: Fix deprecations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ maintainers = [{name = "EDK2 Pytool Maintainers", email = "edk2-pytools@microsof
 dynamic = ["version"]
 description = "Python library supporting UEFI EDK2 firmware development"
 readme = {file = "readme.md", content-type = "text/markdown"}
-license = {file = "LICENSE"}
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
     "pyasn1 >= 0.4.8",
@@ -22,7 +22,6 @@ dependencies = [
 ]
 classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
@@ -60,6 +59,9 @@ docs = [
     "mkdocs-exclude==1.0.2",
     "mkdocs-awesome-pages-plugin==2.9.3",
 ]
+
+[tool.setuptools]
+packages = ["edk2toollib"]
 
 [tool.setuptools_scm]
 


### PR DESCRIPTION
- Fix this deprecation warning:

  > Please use a simple string containing a SPDX expression for
    `project.license`.

  By following guidance at:

  https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-files

- Fix this deprecation warning:

  > Please consider removing the following classifiers in favor of a SPDX license expression:
    License :: OSI Approved :: BSD License

  By removing the license classifier.

- Prevent pyproject from from potentially failing due to package auto discovery by explicitly setting the package to `edk2toolext`.