### PR TITLE
Updating EfiTime to decode bytes

### DIFF
--- a/tests.unit/test_authenticated_variables_structure_support.py
+++ b/tests.unit/test_authenticated_variables_structure_support.py
@@ -983,6 +983,23 @@ class EfiTimeTest(unittest.TestCase):
 
             self.assertEqual(efi_time.encode(), efi_time2.encode())
 
+    def test_EfiTime_from_binary(self):
+        test_data = [
+            ([1970, 1, 1, 0, 0, 0], b"\xb2\x07\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"),
+            ([2022, 12, 5, 12, 33, 5], b"\xe6\x07\x0c\x05\x0c\x21\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00"),
+        ]
+
+        for time_array, expected_bytes in test_data:
+            year, month, day, hour, minute, second = time_array
+            epoch_time = datetime.datetime(year, month, day, hour, minute, second)
+
+            efi_time = EfiTime(time=epoch_time)
+            self.assertEqual(efi_time.encode(), expected_bytes)
+
+            efi_time2 = EfiTime.from_binary(expected_bytes)
+
+            self.assertEqual(efi_time.encode(), efi_time2.encode())
+
 
 # if __name__ == "__main__":
 #    unittest.main()


### PR DESCRIPTION
This pull request introduces several updates to the `EfiTime` class in `edk2toollib/uefi/authenticated_variables_structure_support.py` to improve code readability, add new functionality, and enhance test coverage. The changes include renaming internal attributes for consistency, adding new methods for binary data handling, and updating logging and testing.

### Code readability improvements:
* Renamed `_StructFormat` and `_StructSize` to `_struct_format` and `_struct_size` for consistency with Python naming conventions. 

### New functionality:
* Added a `from_binary` class method to create an `EfiTime` instance from a byte representation.
* Introduced a `get_datetime` method to retrieve the `datetime` object from an `EfiTime` instance.

### Logging updates:
* Updated logging statements in the `decode` method to use f-strings for improved readability and consistency. 

### Test coverage enhancements:
* Added a new test, `test_EfiTime_from_binary`, to validate the `from_binary` method and ensure it correctly reconstructs `EfiTime` instances from byte data. 