### PR TITLE
edk2_db: Fix mis-aligned zip for library dependencies

### DIFF
--- a/edk2toollib/database/tables/instanced_inf_table.py
+++ b/edk2toollib/database/tables/instanced_inf_table.py
@@ -78,14 +78,18 @@ class InstancedInfTable(TableGenerator):
         Inserts all inf's into the instanced_inf table and links source files and used libraries via the junction
         table.
         """
-        # Insert all instanced INF rows
-        rows = []
+
         all_sources = {source.path: source for source in session.query(Source).all()}
         all_packages = {package.name: package for package in session.query(Package).all()}
         all_repos = {
             (repo.name, repo.path): repo for repo in session.query(Repository).filter(Repository.path is not None).all()
         }
         local_repo = session.query(Repository).filter_by(path=None).first()
+
+        # These two variables are zipped together to build the library sub-dependencies
+        # Due to this, we need to make sure we only ever add to both, or they become mis-aligned
+        filtered_inf_entries = []
+        rows = []
         for e in inf_entries:
             # Could parse a Windows INF file, which is not a EDKII INF file
             # and won't have a guid. GUIDS are required for INFs so we can
@@ -115,6 +119,8 @@ class InstancedInfTable(TableGenerator):
                     filter(filter_search, all_repos.values()),
                     local_repo,  # Default
                 )
+            
+            filtered_inf_entries.append(e)
             rows.append(
                 InstancedInf(
                     env=env_id,


### PR DESCRIPTION
This commit fixes a bug that results in a zip of two different sized arrays that must be the same size. This mis-alignment results in recursive library class dependencies being associated with the incorrect parent library or component.

This commit fixes the issue by creating two new lists and only ever appending to both, where as previously a premature continue in a loop had been shown to mis-align the lists.