### PR TITLE
Fixing print statement

### DIFF
--- a/edk2toollib/uefi/authenticated_variables_structure_support.py
+++ b/edk2toollib/uefi/authenticated_variables_structure_support.py
@@ -1330,7 +1330,7 @@ class EfiVariableAuthentication2(CommonUefiStructure):
 
         outfs.write("\n-------------------- VARIABLE PAYLOAD --------------------\n")
         if self.sig_list_payload is not None:
-            self.sig_list_payload.Print()
+            self.sig_list_payload.print(outfs=outfs)
 
         elif self.payload is not None:
             outfs.write("Raw Data: \n")


### PR DESCRIPTION
This pull request includes a minor change to the `print` method in `edk2toollib/uefi/authenticated_variables_structure_support.py`. The change ensures that the `sig_list_payload` object's `print` method is called with the `outfs` argument, aligning it with the method's signature.