### PR TITLE
dsc_parser: Some PCD value not working in !if directive

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/dsc_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/dsc_parser.py
@@ -319,8 +319,6 @@ class DscParser(HashFileParser):
                 # otherwise, raise the exception and act normally
                 if not self._no_fail_mode:
                     raise
-        # Reset the PcdValueDict as this was just to find any Defines.
-        self.PcdValueDict = {}
 
     def _parse_libraries(self) -> None:
         """Builds a lookup table of all possible library instances depending on scope.
@@ -486,6 +484,8 @@ class DscParser(HashFileParser):
         # expand all the lines and include other files
         file_lines = f.readlines()
         self.__ProcessDefines(file_lines)
+        # Reset the PcdValueDict as this was just to find any Defines.
+        self.PcdValueDict = {}
         # reset the parser state before processing more
         self.ResetParserState()
         self._PushTargetFile(sp)


### PR DESCRIPTION
__ProcessDefines is getting called recursively for every !include directive. But PcdValueDict is reset at the end of every instance of __ProcessDefines, which means condition directives can only refer to PCDs assigned in the same .dsc file which is an incorrect behavior.

Moving it out to the ParseFile function, after the very first call of __ProcessDefines so we can refer to PCDs assigned previously in other dsc file and all of them are cleared after processing Defines.

Signed-off-by: PaddyDeng <paddydeng@ami.com>