### PR TITLE
pyproject.toml: Update setuptools to latest (80.9.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
     "pre-commit == 4.0.1",
 ]
 publish = [
-    "setuptools == 75.8.2",
+    "setuptools == 80.9.0",
     "build == 1.2.2.post1",
     "twine == 6.1.0",
 ]


### PR DESCRIPTION
Update the minimum setuptools version to the latest version (80.9.0) to ensure PYSEC-2025-49 is mitigated.

https://osv.dev/vulnerability/PYSEC-2025-49