### PR TITLE
worfklows: run-ci: Inherit secrets for run on `master` branch

### DIFF
--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -33,8 +33,7 @@ jobs:
     uses: ./.github/workflows/UnitTestRunner.yml
     with:
       python-versions: ${{ needs.variables.outputs.python-msv }}
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    secrets: inherit
 
   unit-test:
     needs: [variables,ci]
@@ -42,5 +41,4 @@ jobs:
     uses: ./.github/workflows/UnitTestRunner.yml
     with:
       python-versions: ${{ needs.variables.outputs.python-versions }}
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    secrets: inherit


### PR DESCRIPTION
Inherits secrets to the unit test workflow so that when it runs on the master branch (which requires the CODECOV_TOKEN secret exist to upload results), it is available. On pull requests with forks, the token is not passed through, but codecov does not require the token exist for pull requests.