### PR TITLE
Fix build report parsing for long files

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/buildreport_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/buildreport_parser.py
@@ -346,7 +346,7 @@ class BuildReport(object):
             a = rawcontents[index]
             tokens = a.split()
             if a.startswith("0x") and (len(tokens) == 3) and (a.count("(") == 1):
-                if ".inf" not in a.lower() or (a.count("(") != a.count(")")):
+                while ".inf" not in a.lower() or (a.count("(") != a.count(")")):
                     a = a + rawcontents[index + 1].strip()
                     index += 1
                     tokens = a.split()


### PR DESCRIPTION
## Description
Fix build report parsing for long file names

## How This Was Tested
Errors no longer observed while building files with long names