### PR TITLE
edk2toollib: Fix Pcds are not parsed when next to symbol

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/dsc_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/dsc_parser.py
@@ -64,7 +64,7 @@ class DscParser(HashFileParser):
     def ReplacePcds(self, line: str) -> str:
         """Attempts to replace a token if it is a PCD token."""
         if line.startswith("!if"):
-            for token in line.split():
+            for token in re.split(r"[^\w\.]", line):
                 if token in self.PcdValueDict:
                     line = line.replace(token, self.PcdValueDict[token])
         return line

--- a/tests.unit/parsers/test_dsc_parser.py
+++ b/tests.unit/parsers/test_dsc_parser.py
@@ -224,3 +224,28 @@ class TestDscParserIncludes(unittest.TestCase):
         parser.ParseFile(file1_path)
 
         self.assertEqual(parser.LocalVars["INCLUDE"], "TRUE")
+
+    def test_dsc_pcd_mix_with_symbols(self):
+        """This tests pcd can be parsed correctly when next to symbols"""
+        workspace = tempfile.mkdtemp()
+
+        file_name = "test.dsc"
+        file_path = os.path.join(workspace, file_name)
+
+        file_data = textwrap.dedent("""\
+        [PcdsFixedAtBuild]
+            gFakePcdTokenSpaceGuid.PcdFake1|0xAB
+            gFakePcdTokenSpaceGuid.PcdFake2|TRUE
+
+        [Defines]
+        !if (gFakePcdTokenSpaceGuid.PcdFake1>=0xA0)&&(gFakePcdTokenSpaceGuid.PcdFake2==TRUE)
+            INCLUDE=TRUE
+        !endif
+        """)
+
+        TestDscParserIncludes.write_to_file(file_path, file_data)
+
+        parser = DscParser().SetEdk2Path(Edk2Path(workspace, []))
+        parser.ParseFile(file_path)
+
+        self.assertEqual(parser.LocalVars["INCLUDE"], "TRUE")


### PR DESCRIPTION
The original string.split in ReplacePcds yelds incorrect result when the pcd is right next to symbols.

Sign-off-by: Paddy Deng <paddydeng@ami.com>