### PR TITLE
locate_tools: Add VS2026 Support

### DIFF
--- a/edk2toollib/windows/locate_tools.py
+++ b/edk2toollib/windows/locate_tools.py
@@ -48,7 +48,12 @@ __SHA256 = "c54f3b7c9164ea9a0db8641e81ecdda80c2664ef5a47c4191406f848cc07c662"
 # Supported Versions that can be queried with vswhere
 # Use lower case for key as all comparisons will be lower case
 #
-supported_vs_versions = {"vs2017": "15.0,16.0", "vs2019": "16.0,17.0", "vs2022": "17.0,18.0"}
+supported_vs_versions = {
+    "vs2017": "15.0,16.0",
+    "vs2019": "16.0,17.0",
+    "vs2022": "17.0,18.0",
+    "vs2026": "18.0,19.0",
+}
 
 
 # Downloads VSWhere

--- a/tests.unit/test_locate_tools.py
+++ b/tests.unit/test_locate_tools.py
@@ -51,6 +51,11 @@ class LocateToolsTest(unittest.TestCase):
         # not checking the result as no need to depend on machine state
 
     @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
+    def test_FindwithVsWhereVs2026(self):
+        locate_tools.FindWithVsWhere(vs_version="vs2026")
+        # not checking the result as no need to depend on machine state
+
+    @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
     def test_FindWithVsWhereVs2015(self):
         with self.assertRaises(ValueError):
             locate_tools.FindWithVsWhere(vs_version="vs2015")


### PR DESCRIPTION
This adds support to locate_tools.py for VS2026. Before this change the script exits with unsupported version.