### PR TITLE
tests.unit: Change QemuSbsaPkg to QemuArmVirtPkg

### DIFF
--- a/tests.unit/database/test_package_table.py
+++ b/tests.unit/database/test_package_table.py
@@ -37,7 +37,7 @@ def test_basic_parse(tmp_path):
 
         to_pass = {
             ("QemuPkg", "MU_TIANO_PLATFORMS"): False,
-            ("QemuSbsaPkg", "MU_TIANO_PLATFORMS"): False,
+            ("QemuArmVirtPkg", "MU_TIANO_PLATFORMS"): False,
             ("QemuQ35Pkg", "MU_TIANO_PLATFORMS"): False,
             ("SetupDataPkg", "Features/CONFIG"): False,
         }


### PR DESCRIPTION
QemuSbsaPkg was recently named to QemuArmVirtPkg in mu_tiano_platforms. The package name is updated in `test_basic_parse()` to reflect the change.