### PR TITLE
fdf_parser: Fix RecursionError on long runs of skipped lines

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/fdf_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/fdf_parser.py
@@ -44,27 +44,29 @@ class FdfParser(HashFileParser):
         Performs manipulation on the line like replacing variables,
         processing conditionals, etc.
         """
-        if len(self.Lines) == 0:
-            return None
+        # Iterative (not recursive) to avoid hitting Python's recursion limit on long
+        # runs of skipped lines (comments/blanks or large inactive !if blocks).
+        while len(self.Lines) > 0:
+            line = self.Lines.pop()
+            self.CurrentLine += 1
+            sline = self.StripComment(line)
 
-        line = self.Lines.pop()
-        self.CurrentLine += 1
-        sline = self.StripComment(line)
+            if sline is None or len(sline) < 1:
+                continue
 
-        if sline is None or len(sline) < 1:
-            return self.GetNextLine()
+            sline = self.ReplaceVariables(sline)
+            if self.ProcessConditional(sline):
+                # was a conditional so skip
+                continue
+            if not self.InActiveCode():
+                continue
 
-        sline = self.ReplaceVariables(sline)
-        if self.ProcessConditional(sline):
-            # was a conditional so skip
-            return self.GetNextLine()
-        if not self.InActiveCode():
-            return self.GetNextLine()
+            self._BracketCount += sline.count("{")
+            self._BracketCount -= sline.count("}")
 
-        self._BracketCount += sline.count("{")
-        self._BracketCount -= sline.count("}")
+            return sline
 
-        return sline
+        return None
 
     def InsertLinesFromFile(self, file_path: str) -> None:
         """Adds additional lines to the Lines Attribute from the provided file."""

--- a/tests.unit/parsers/test_fdf_parser.py
+++ b/tests.unit/parsers/test_fdf_parser.py
@@ -179,3 +179,43 @@ def test_file_raw_section_statements():
     assert "a_ui.bin" in parser.FVs["MAINFV"]["Files"]["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]["UI"]
     assert "some_efi_file.efi" in parser.FVs["MAINFV"]["Files"]["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]["PE32"]
     assert "some_te.te" in parser.FVs["MAINFV"]["Files"]["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]["TE"]
+
+
+def test_long_run_of_skipped_comment_and_blank_lines():
+    """Regression: a long run of skipped comment/blank lines must not raise RecursionError."""
+    lines = ["[Defines]", "DEFINE FD_BASE = 0x00800000"]
+    lines += ["# a skipped comment line"] * 5000
+    lines += [""] * 5000
+    lines += ["DEFINE NUM_BLOCKS = 0x410"]
+    try:
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", suffix=".fdf", delete=False) as f:
+            f.write("\n".join(lines) + "\n")
+            fdf_path = f.name
+        parser = FdfParser()
+        parser.ParseFile(fdf_path)
+    finally:
+        os.remove(fdf_path)
+
+    # The definition after the long skipped run is still parsed correctly.
+    assert parser.Dict["FD_BASE"] == "0x00800000"
+    assert parser.Dict["NUM_BLOCKS"] == "0x410"
+
+
+def test_long_inactive_conditional_block():
+    """Regression: a large inactive !if block must not raise RecursionError."""
+    lines = ["[Defines]", "DEFINE FD_BASE = 0x00800000", "!if 0"]
+    lines += ["DEFINE SKIPPED = 0x1"] * 5000
+    lines += ["!endif", "DEFINE NUM_BLOCKS = 0x410"]
+    try:
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", suffix=".fdf", delete=False) as f:
+            f.write("\n".join(lines) + "\n")
+            fdf_path = f.name
+        parser = FdfParser()
+        parser.ParseFile(fdf_path)
+    finally:
+        os.remove(fdf_path)
+
+    assert parser.Dict["FD_BASE"] == "0x00800000"
+    assert parser.Dict["NUM_BLOCKS"] == "0x410"
+    # Lines inside the inactive block are not parsed.
+    assert "SKIPPED" not in parser.Dict


### PR DESCRIPTION
FdfParser.GetNextLine() skipped comments, blank lines, conditionals, and inactive !if lines by recursing, adding a stack frame per skipped line. A long run of skipped lines (e.g. an !included file wholly wrapped in a false !if block) exceeds Python's recursion limit (1000 by default) and raises RecursionError, aborting the parse.

Rewrite GetNextLine() as an equivalent while loop, turning each skip into a continue. Behavior is unchanged but stack depth no longer grows with the number of skipped lines. This also matches DscParser, which already iterates.