### PR TITLE
dsc_parser: Restore TargetFilePath after nested !include

### DIFF
--- a/edk2toollib/uefi/edk2/parsers/dsc_parser.py
+++ b/edk2toollib/uefi/edk2/parsers/dsc_parser.py
@@ -60,6 +60,7 @@ class DscParser(HashFileParser):
         self.PcdValueDict = {}
         self._no_fail_mode = False
         self._dsc_file_paths = set()  # This includes the full paths for every DSC that makes up the file
+        self._target_file_stack = []  # previous TargetFilePath values for nested !include
 
     def ReplacePcds(self, line: str) -> str:
         """Attempts to replace a token if it is a PCD token."""
@@ -289,6 +290,8 @@ class DscParser(HashFileParser):
                 if len(line) > 0:
                     self.Lines.append(line)
                 self.__ProcessMore(add, file_name=new_file)
+                if add:
+                    self._PopTargetFile()
             except Exception as e:
                 # check if we're in no fail mode or not
                 if not self._no_fail_mode:  # if we are, fail
@@ -314,6 +317,8 @@ class DscParser(HashFileParser):
             try:
                 (line, add) = self.__ParseDefineLine(raw_line)
                 self.__ProcessDefines(add)
+                if add:
+                    self._PopTargetFile()
             except Exception:
                 # Since we're going to do this in ProcessMore, don't warn people if there's an exception
                 # otherwise, raise the exception and act normally
@@ -472,6 +477,7 @@ class DscParser(HashFileParser):
         # add more DSC parser based state reset here, if necessary
         #
         super(DscParser, self).ResetParserState()
+        self._target_file_stack = []
 
     def ParseFile(self, filepath: str) -> None:
         """Parses the DSC file at the provided path."""
@@ -496,8 +502,14 @@ class DscParser(HashFileParser):
         self.Parsed = True
 
     def _PushTargetFile(self, targetFile: str) -> None:
+        if self.TargetFilePath:
+            self._target_file_stack.append(self.TargetFilePath)
         self.TargetFilePath = os.path.abspath(targetFile)
         self._dsc_file_paths.add(self.TargetFilePath)
+
+    def _PopTargetFile(self) -> None:
+        if self._target_file_stack:
+            self.TargetFilePath = self._target_file_stack.pop()
 
     def GetMods(self) -> list:
         """Returns a list with all Mods."""

--- a/tests.unit/parsers/test_dsc_parser.py
+++ b/tests.unit/parsers/test_dsc_parser.py
@@ -157,6 +157,38 @@ class TestDscParserIncludes(unittest.TestCase):
         finally:
             os.chdir(cwd)
 
+    def test_dsc_two_sibling_relative_includes(self):
+        """Sibling !include paths are resolved from the parent, not the previous include (issue 394)."""
+        workspace = tempfile.mkdtemp()
+        pkg = os.path.join(workspace, "Platforms", "PlatformPkg")
+        includes = os.path.join(pkg, "includes")
+        os.makedirs(includes, exist_ok=True)
+
+        parent = os.path.join(pkg, "PlatformPkg.dsc")
+        inc1 = os.path.join(includes, "PCDs1.dsc.inc")
+        inc2 = os.path.join(includes, "PCDs2.dsc.inc")
+
+        TestDscParserIncludes.write_to_file(
+            parent,
+            textwrap.dedent(
+                """\
+                [Defines]
+                    PLATFORM_NAME = SomePlatformPkg
+                !include includes/PCDs1.dsc.inc
+                !include includes/PCDs2.dsc.inc
+                """
+            ),
+        )
+        TestDscParserIncludes.write_to_file(inc1, "    DEFINE FIRST_INC = TRUE\n")
+        TestDscParserIncludes.write_to_file(inc2, "    DEFINE SECOND_INC = TRUE\n")
+
+        parser = DscParser()
+        parser.SetEdk2Path(Edk2Path(workspace, []))
+        parser.ParseFile(parent)
+
+        self.assertEqual(parser.LocalVars.get("FIRST_INC"), "TRUE")
+        self.assertEqual(parser.LocalVars.get("SECOND_INC"), "TRUE")
+
     def test_dsc_define_statements(self):
         """This test some dsc define statements"""
         SAMPLE_DSC_FILE1 = textwrap.dedent("""\


### PR DESCRIPTION
## Description

`FindPath` resolves `!include` first relative to the file currently being parsed. After reading an include, `TargetFilePath` stayed on that include, so a second sibling include was joined onto the include directory and failed.

This pushes and pops `TargetFilePath` around include expansion so sibling relative includes resolve from the parent again.

Fixes #394

## Testing

- `python -m pytest tests.unit/parsers/test_dsc_parser.py::TestDscParserIncludes`
- `python -m pytest tests.unit` (414 passed, 4 skipped)