### PR TITLE
Update EDK2Path class to handle os.PathLike objects correctly for Python 3.14+

### DIFF
--- a/edk2toollib/uefi/edk2/path_utilities.py
+++ b/edk2toollib/uefi/edk2/path_utilities.py
@@ -58,11 +58,11 @@ class Edk2Path(object):
         # Other code is dependent the following types, so keep it that way:
         #   - self.PackagePathList: List[str]
         #   - self.WorkspacePath: str
-        ws = ws.replace("\\", "/")
-        workspace_candidate_path = Path(ws)
+        normalized_workspace = ws.replace("\\", "/") if isinstance(ws, str) else ws
+        workspace_candidate_path = Path(normalized_workspace)
 
         if not workspace_candidate_path.is_absolute():
-            workspace_candidate_path = Path.cwd() / ws
+            workspace_candidate_path = Path.cwd() / normalized_workspace
 
         if not workspace_candidate_path.is_dir():
             raise NotADirectoryError(errno.ENOENT, os.strerror(errno.ENOENT), workspace_candidate_path.resolve())
@@ -71,7 +71,11 @@ class Edk2Path(object):
 
         candidate_package_path_list = []
         start_time = timeit.default_timer()
-        for a in [Path(path.replace("\\", "/")) for path in package_path_list]:
+        for path in package_path_list:
+            if isinstance(path, str):
+                path = path.replace("\\", "/")
+
+            a = Path(path)
             if a.is_absolute():
                 candidate_package_path_list.append(a)
             else:

--- a/tests.unit/test_path_utilities.py
+++ b/tests.unit/test_path_utilities.py
@@ -83,6 +83,17 @@ class PathUtilitiesTest(unittest.TestCase):
         pathobj = Edk2Path(self.tmp, [])
         self.assertEqual(pathobj.WorkspacePath, self.tmp)
 
+    def test_basic_init_pathlike(self):
+        """Test edk2path with Path objects for the workspace and package path."""
+        workspace_path = Path(self.tmp)
+        package_path = workspace_path / "package_path"
+        package_path.mkdir()
+
+        pathobj = Edk2Path(workspace_path, [package_path])
+
+        self.assertEqual(pathobj.WorkspacePath, str(workspace_path))
+        self.assertEqual(pathobj.PackagePathList, [str(package_path)])
+
     def test_basic_init_ws_cwd(self):
         """Test edk2path with a relative path to workspace."""
         relpath = "testrootfolder"


### PR DESCRIPTION
The change makes `Edk2Path` support `os.PathLike` inputs, as its type annotations promise.

- Workspace paths are slash-normalized only when they are strings.
- Package paths receive the same conditional handling through an explicit loop.

Previously, passing a `pathlib.Path` called its filesystem `replace()` method as though it were `str.replace()`, causing a `TypeError`. Other `PathLike` implementations could raise `AttributeError`.

The fix preserves existing string behavior, including Windows separator support, while allowing `Path` objects to pass safely into `Path(...)`. This aligns runtime behavior with the public API and avoids forcing callers to use `str(path)`. Added a unit test to verify pathlike support.